### PR TITLE
Add tools-debug to genivi-dev-platform image by default, as now 'development platform'

### DIFF
--- a/meta-genivi-dev/recipes-dev-platform/images/genivi-dev-platform.bb
+++ b/meta-genivi-dev/recipes-dev-platform/images/genivi-dev-platform.bb
@@ -14,6 +14,7 @@ BOOT_SPACE_raspberrypi2 = "40960"
 
 IMAGE_FEATURES_append = " \
     ssh-server-openssh    \
+    tools-debug           \
     "
 
 IMAGE_INSTALL_append = " \


### PR DESCRIPTION
…lopment platform'
