### PR TITLE
Add packagegroup-gdp-rvi to genivi-dev-platform image

### DIFF
--- a/meta-genivi-dev/recipes-dev-platform/images/genivi-dev-platform.bb
+++ b/meta-genivi-dev/recipes-dev-platform/images/genivi-dev-platform.bb
@@ -29,6 +29,7 @@ IMAGE_INSTALL_append = " \
     packagegroup-gdp-gps \
     packagegroup-gdp-hmi \
     packagegroup-gdp-qt5 \
+    packagegroup-gdp-rvi \
     boost \
     "
 

--- a/meta-genivi-dev/recipes-dev-platform/packagegroups/packagegroup-gdp-rvi.bb
+++ b/meta-genivi-dev/recipes-dev-platform/packagegroups/packagegroup-gdp-rvi.bb
@@ -1,0 +1,19 @@
+DESCRIPTION = "GENIVI Remote Vehicle Interaction (RVI) package group"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${IVI_COREBASE}/meta-ivi/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
+
+# Avoid hardcoding the full layer path into the checksums
+LIC_FILES_CHKSUM[vardepsexclude] += "IVI_COREBASE"
+
+inherit packagegroup
+
+PACKAGES = "\
+    packagegroup-gdp-rvi \
+    "
+
+ALLOW_EMPTY_${PN} = "1"
+
+RDEPENDS_${PN} += "\
+    rvi \
+    rvi-sota-client \
+    "


### PR DESCRIPTION
Group rvi components into a 'rvi' packagegroup, and include this in the default GDP image. This approach will allow new components from rvi to be added once to this packagegroup. Including @leon-anavi as he brought rvi sota/core into GDP
