### PR TITLE
genivi-dev-platform: Remove boost runtime dependency

### DIFF
--- a/meta-genivi-dev/recipes-dev-platform/images/genivi-dev-platform.bb
+++ b/meta-genivi-dev/recipes-dev-platform/images/genivi-dev-platform.bb
@@ -30,7 +30,6 @@ IMAGE_INSTALL_append = " \
     packagegroup-gdp-hmi \
     packagegroup-gdp-qt5 \
     packagegroup-gdp-rvi \
-    boost \
     "
 
 IMAGE_INSTALL_append_rcar-gen2 = " \


### PR DESCRIPTION
boost is library and library should be used by demon or service's
dependency (not in image and packagegroup by default). In GDP,
automotive-message-broker requires boost and has dependency with it.

Signed-off-by: Changhyeok Bae changhyeok.bae@gmail.com
