### PR TITLE
rvi-sota-client: Add openssl as a dependency

### DIFF
--- a/meta-genivi-dev/recipes-sota/rvi-sota-client/rvi-sota-client_git.bb
+++ b/meta-genivi-dev/recipes-sota/rvi-sota-client/rvi-sota-client_git.bb
@@ -14,7 +14,7 @@ S = "${WORKDIR}/git"
 
 BBCLASSEXTEND = "native"
 
-DEPENDS += "dbus"
+DEPENDS += "dbus openssl"
 RDEPENDS_${PN} += "dbus-lib libcrypto libssl"
 
 SYSTEMD_SERVICE_${PN} = "rvi-sota-client.service"


### PR DESCRIPTION
Fix an issue when reusing sstate cache for
building RVI SOTA client by adding openssl as a
dependency.

[GDP-249] go.cd pipelines failing to compile rust (issue in rustc)

Signed-off-by: Leon Anavi leon.anavi@konsulko.com
