### PR TITLE
Switch initial genivi SRC_URI from git.projects.genivi.org to Github

### DIFF
--- a/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/genivi-dev-platform-hmi.inc
+++ b/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/genivi-dev-platform-hmi.inc
@@ -5,5 +5,5 @@ HOMEPAGE = "http://projects.genivi.org/genivi-demo-platform/"
 LICENSE  = "MPL-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=815ca599c9df247a0c7f619bab123dad"
 
-SRC_URI = "git://git.projects.genivi.org/genivi-demo-platform-hmi.git;protocol=http"
+SRC_URI = "git://github.com/GENIVI/gdp-hmi.git"
 SRCREV  = "f7072c3e4e0681123e9fce90dbcccb49e42275a4"

--- a/meta-genivi-dev/recipes-extended/browser-poc/browser-poc_git.bb
+++ b/meta-genivi-dev/recipes-extended/browser-poc/browser-poc_git.bb
@@ -9,7 +9,7 @@ SRCREV = "231265ba9cc7581f8fb36d9e7f862f211d43564a"
 
 DEPENDS = "qtbase qtwebkit"
 
-SRC_URI = "git://git.projects.genivi.org/browser-poc.git;protocol=http \
+SRC_URI = "git://github.com/GENIVI/browser-poc.git \
            file://browser_poc_smaller_bookmarks_qml.patch \
            file://browser.service \
            file://demoui.service \

--- a/meta-genivi-dev/recipes-multimedia/audiomanager/gdp-audiomanager-monitor.bb
+++ b/meta-genivi-dev/recipes-multimedia/audiomanager/gdp-audiomanager-monitor.bb
@@ -5,14 +5,13 @@ LICENSE = "MPLv2"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=815ca599c9df247a0c7f619bab123dad"
 DEPENDS = "qtbase qtdeclarative pulseaudio audiomanager"
 
-BRANCH="master"
+SRCREV = "eea896440e5ad49622c7b1a4095f0d63c3465aa2"
 
 SRC_URI = "\
-    git://git.projects.genivi.org/AudioManagerDemo.git;branch=${BRANCH};protocol=http \
+    git://github.com/GENIVI/audio-manager-demo.git \
     file://AudioManager_Monitor.service \
     file://0001-gdp-audio-monitor-include-fix.patch \
     "
-SRCREV = "eea896440e5ad49622c7b1a4095f0d63c3465aa2"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Includes: genivi-dev-platform-hmi, browser-poc & gdp-audiomanager-monitor
Pending: wayland-ivi-extension & audiomanager
