### PR TITLE
Update audiomanager SRC_URI_remove to match meta-ivi change

### DIFF
--- a/meta-genivi-dev/recipes-multimedia/audiomanager/audiomanager_7.0.bbappend
+++ b/meta-genivi-dev/recipes-multimedia/audiomanager/audiomanager_7.0.bbappend
@@ -5,7 +5,7 @@ DEPENDS_append = " pulseaudio"
 SRCREV_am = "8725157e248c6706de59a02996f869b6ccdccb13"
 SRCREV_amp = "a0ed3b8f05147e9240d941655488d505057bbae7"
 
-SRC_URI_remove = "git://git.projects.genivi.org/AudioManager.git;branch=master"
+SRC_URI_remove = "git://git.projects.genivi.org/AudioManager.git;branch=master;protocol=http"
 
 SRC_URI_append = " git://git.projects.genivi.org/AudioManager.git;branch=master;protocol=http;name=am \
                    git://git.projects.genivi.org/AudioManagerPlugins.git;destsuffix=git/Plugins;branch=master;protocol=http;name=amp \
@@ -49,7 +49,7 @@ FILES_${PN} += " \
     "
 
 FILES_${PN}-dev_remove = "${libdir}/*"
-FILES_${PN}-dev += "${libdir}/${PN}/cmake"
+FILES_${PN}-dev += "${libdir}/cmake"
 
 FILES_${PN}-dbg += " \
     ${libdir}/audiomanager/command/.debug/* \


### PR DESCRIPTION
meta-ivi: dcfc3e68 "Use http protocol to fetch sources (OSSINFR-30)"
Updating to meta-ivi 10.0.1 release includes this commit in which
SRC_URI for the audiomanager upstream string is changed.
