### PR TITLE
Switching gdp-hmi.inc to use autorev for SRCREV

### DIFF
--- a/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/genivi-dev-platform-hmi.inc
+++ b/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/genivi-dev-platform-hmi.inc
@@ -5,5 +5,5 @@ HOMEPAGE = "http://projects.genivi.org/genivi-demo-platform/"
 LICENSE  = "MPL-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=815ca599c9df247a0c7f619bab123dad"
 
-SRC_URI = "git://github.com/GENIVI/gdp-hmi.git"
-SRCREV  = "f7072c3e4e0681123e9fce90dbcccb49e42275a4"
+SRC_URI = "git://github.com/GENIVI/gdp-hmi.git;branch=master"
+SRCREV = "${AUTOREV}"


### PR DESCRIPTION
gdp-hmi has no context outside of the GDP system,
as such the tip of master should always be built.
This reduces the need to generate a commit to update
SRCREV and in-turn g-d-p.git for each new revision.
