### PR TITLE
meta-intel-gdp: Update faytech monitor patch & README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ URI: git://github.com/slawr/meta-renesas.git
 
 ## The Intel Minnowboard MAX depends in addition on: ##
 URI: git://git.yoctoproject.org/meta-intel
-* branch: jethro
-* revision: 2397181e99d3155c7a00e1756cec92b568d9a9eb
+* branch: krogoth
+* revision: b8c199201ffe026485a14e1fcfc398e2b3551512
 
 ## The Qualcomm Dragonboard 410c depends in addition on: ##
 URI: git://git.yoctoproject.org/meta-qcom

--- a/meta-intel-gdp/recipes-kernel/linux/linux-yocto/0001-faytech-fix-minnow.patch
+++ b/meta-intel-gdp/recipes-kernel/linux/linux-yocto/0001-faytech-fix-minnow.patch
@@ -5,14 +5,11 @@ Subject: [PATCH 1/1] Fix lack of touch up for Faytech 10" Touchscreen MonitorV2
 
 NOTE: This is a very temporary hack that is not in a state to be upstreamed yet.
 ---
- drivers/hid/hid-multitouch.c | 1 -
- 1 file changed, 1 deletion(-)
-
-diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
-index 6a9b05b..4647b5b 100644
---- a/drivers/hid/hid-multitouch.c
-+++ b/drivers/hid/hid-multitouch.c
-@@ -205,7 +205,6 @@ static struct mt_class mt_classes[] = {
+Index: a/drivers/hid/hid-multitouch.c
+===================================================================
+--- a/drivers/hid/hid-multitouch.c	2016-07-05 08:45:06.006466000 +0000
++++ b/drivers/hid/hid-multitouch.c	2016-07-05 08:48:44.574466000 +0000
+@@ -205,7 +205,6 @@
  	{ .name = MT_CLS_WIN_8,
  		.quirks = MT_QUIRK_ALWAYS_VALID |
  			MT_QUIRK_IGNORE_DUPLICATES |
@@ -20,5 +17,17 @@ index 6a9b05b..4647b5b 100644
  			MT_QUIRK_CONTACT_CNT_ACCURATE },
  	{ .name = MT_CLS_EXPORT_ALL_INPUTS,
  		.quirks = MT_QUIRK_ALWAYS_VALID |
+@@ -396,11 +395,6 @@
+ 			td->is_buttonpad = true;
+ 
+ 		break;
+-	case 0xff0000c5:
+-		/* Retrieve the Win8 blob once to enable some devices */
+-		if (usage->usage_index == 0)
+-			mt_get_feature(hdev, field->report);
+-		break;
+ 	}
+ }
+ 
 -- 
 1.9.1


### PR DESCRIPTION
meta-intel krogoth branch (Yocto 2.1) switches to linux-yocto 4.4
faytech HID_MULTITOUCH patch V2 taken from meta-raspberrypi-gdp.
README also updated for meta-intel krogoth ref
