### PR TITLE
linux-raspberrypi: Update deconfig patch for linux 4.4.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ URI: git://github.com/joaohf/meta-erlang.git
 
 URI: git://git.yoctoproject.org/meta-raspberrypi
 * branch:   master
-* revision: 9912d38e97671704822d1aa05312a0439cb650d3
+* revision: 2745399f75d7564fcc586d0365ff73be47849d0e
 
 ## The Renesas R-Car Gen2 Koelsch & Porter boards depend in addition on: ##
 URI: git://github.com/slawr/meta-renesas.git

--- a/meta-raspberrypi-gdp/recipes-kernel/linux/linux-raspberrypi/0001-rpi2-defconfig.patch
+++ b/meta-raspberrypi-gdp/recipes-kernel/linux/linux-raspberrypi/0001-rpi2-defconfig.patch
@@ -1,17 +1,17 @@
-From 42d9705d47ad7b89473a5ca8fc2990e71502b1aa Mon Sep 17 00:00:00 2001
+From 8fc74e958e6cfac398e2a5e79ab975d6cb3a4f17 Mon Sep 17 00:00:00 2001
 From: Changhyeok Bae <changhyeok.bae@gmail.com>
 Date: Mon, 9 May 2016 16:17:30 +0900
-Subject: [PATCH] rpi2 defconfig
+Subject: [PATCH 1/1] rpi2 defconfig
 
 ---
- arch/arm/configs/bcm2709_defconfig |    7 ++++---
+ arch/arm/configs/bcm2709_defconfig | 7 ++++---
  1 file changed, 4 insertions(+), 3 deletions(-)
 
 diff --git a/arch/arm/configs/bcm2709_defconfig b/arch/arm/configs/bcm2709_defconfig
-index 54c8f4e..57f1f43 100644
+index a8d7790..255145f 100644
 --- a/arch/arm/configs/bcm2709_defconfig
 +++ b/arch/arm/configs/bcm2709_defconfig
-@@ -604,6 +604,7 @@ CONFIG_I2C=y
+@@ -606,6 +606,7 @@ CONFIG_I2C=y
  CONFIG_I2C_CHARDEV=m
  CONFIG_I2C_MUX_PCA954x=m
  CONFIG_I2C_BCM2708=m
@@ -19,13 +19,15 @@ index 54c8f4e..57f1f43 100644
  CONFIG_I2C_GPIO=m
  CONFIG_SPI=y
  CONFIG_SPI_BCM2835=m
-@@ -814,11 +815,11 @@ CONFIG_VIDEO_TW9903=m
+@@ -816,13 +817,13 @@ CONFIG_VIDEO_TW9903=m
  CONFIG_VIDEO_TW9906=m
  CONFIG_VIDEO_OV7640=m
  CONFIG_VIDEO_MT9V011=m
 -CONFIG_DRM=m
 +CONFIG_DRM=y
+ CONFIG_DRM_LOAD_EDID_FIRMWARE=y
  CONFIG_DRM_UDL=m
+ CONFIG_DRM_PANEL_SIMPLE=m
 -CONFIG_DRM_VC4=m
 +CONFIG_DRM_VC4=y
  CONFIG_FB=y
@@ -35,5 +37,5 @@ index 54c8f4e..57f1f43 100644
  CONFIG_FB_SSD1307=m
  CONFIG_FB_RPISENSE=m
 -- 
-1.7.9.5
+1.9.1
 


### PR DESCRIPTION
meta-raspberrypi master 101e8ab supports linux kernel 4.4.13
deconfig patch for vc4 driver rebased to support this source.
