### PR TITLE
pulseaudio: Set minnowboard specific configuration for am_poc.pa

### DIFF
--- a/meta-genivi-dev/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
+++ b/meta-genivi-dev/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
@@ -6,6 +6,10 @@ SRC_URI_append = " file://client_conf.patch \
                    file://pulseaudio_user.service \
 "
 
+do_install_append_intel-corei7-64() {
+    sed -i -e "40s/device=hw:0,0/device=hw:0,3/" ${WORKDIR}/am_poc.pa
+}
+
 do_install_append() {
     cp ${WORKDIR}/am_poc.pa ${D}/etc/pulse
     mkdir -p ${D}//etc/systemd/user


### PR DESCRIPTION
[GDP-329] Pulseaudio user service failing on Minnowboard GDP11 Master

Minnowboard audio playback device is configured as card 0 device 3
