### PR TITLE
rpi-config: Fix bluetooth launch issue in rpi3

### DIFF
--- a/meta-raspberrypi-gdp/recipes-bsp/bootfiles/rpi-config_git.bbappend
+++ b/meta-raspberrypi-gdp/recipes-bsp/bootfiles/rpi-config_git.bbappend
@@ -9,7 +9,3 @@ do_deploy_append() {
 }
 
 ENABLE_UART_raspberrypi3 = "1"
-
-do_deploy_append_raspberrypi3() {
-    echo "dtoverlay=pi3-miniuart-bt-overlay" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-}


### PR DESCRIPTION
[GDP-333] Bluetooth not working on RPI3 (brcm4348.service failed)

Signed-off-by: Changhyeok Bae changhyeok.bae@gmail.com
