### PR TITLE
Fix encoding error on RPI

### DIFF
--- a/meta-genivi-dev/recipes-qt/qt5/qtquickcontrols/0001-Correct-label-on-RPI.patch
+++ b/meta-genivi-dev/recipes-qt/qt5/qtquickcontrols/0001-Correct-label-on-RPI.patch
@@ -1,0 +1,26 @@
+From 9cf1db27878a02307febce96ff23487a15d30ecb Mon Sep 17 00:00:00 2001
+From: a629114 <a629114@aw.atos.net>
+Date: Thu, 1 Sep 2016 16:34:31 +0200
+Subject: [PATCH] Correct label on RPI
+
+---
+ src/controls/Label.qml | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/src/controls/Label.qml b/src/controls/Label.qml
+index b07e96d..9835df3 100644
+--- a/src/controls/Label.qml
++++ b/src/controls/Label.qml
+@@ -82,8 +82,7 @@ Text {
+ 
+     id: label
+     color: pal.windowText
+-    activeFocusOnTab: false
+-    renderType: Settings.isMobile ? Text.QtRendering : Text.NativeRendering
++    activeFocusOnTab: false    
+     SystemPalette {
+         id: pal
+         colorGroup: enabled ? SystemPalette.Active : SystemPalette.Disabled
+-- 
+2.1.4
+

--- a/meta-genivi-dev/recipes-qt/qt5/qtquickcontrols/0002-Correct-textfield-on-RPI.patch
+++ b/meta-genivi-dev/recipes-qt/qt5/qtquickcontrols/0002-Correct-textfield-on-RPI.patch
@@ -1,0 +1,33 @@
+From a62b5180444055b05b9723f125fb5312d514e733 Mon Sep 17 00:00:00 2001
+From: a629114 <a629114@aw.atos.net>
+Date: Thu, 1 Sep 2016 16:39:35 +0200
+Subject: [PATCH 2/2] Correct textfield on RPI
+
+---
+ src/controls/TextField.qml | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/src/controls/TextField.qml b/src/controls/TextField.qml
+index c5d5d2b..fbe5581 100644
+--- a/src/controls/TextField.qml
++++ b/src/controls/TextField.qml
+@@ -629,7 +629,6 @@ Control {
+         color: __panel ? __panel.placeholderTextColor : "darkgray"
+         clip: contentWidth > width;
+         elide: Text.ElideRight
+-        renderType: __style ? __style.renderType : Text.NativeRendering
+     }
+ 
+     TextInputWithHandles {
+@@ -656,8 +655,6 @@ Control {
+         color: __panel ? __panel.textColor : "darkgray"
+         clip: contentWidth > width
+ 
+-        renderType: __style ? __style.renderType : Text.NativeRendering
+-
+         Keys.forwardTo: textfield
+ 
+         EnterKey.type: control.EnterKey.type
+-- 
+2.1.4
+

--- a/meta-genivi-dev/recipes-qt/qt5/qtquickcontrols_%.bbappend
+++ b/meta-genivi-dev/recipes-qt/qt5/qtquickcontrols_%.bbappend
@@ -1,0 +1,6 @@
+FILESEXTRAPATHS_append := ":${THISDIR}/${PN}"
+
+SRC_URI_append_rpi = "\
+    file://0001-Correct-label-on-RPI.patch \
+    file://0002-Correct-textfield-on-RPI.patch \
+"


### PR DESCRIPTION
[GDP-332] Encoding problems in qml-example on gdp master using a RPI2/3

Update qtquickcontrols recipe : remove renderType parameters in some qml files
