### PR TITLE
automotive-message-broker: disable icecc explicitly

### DIFF
--- a/meta-genivi-dev/recipes-extended/automotive-message-broker/automotive-message-broker_git.bb
+++ b/meta-genivi-dev/recipes-extended/automotive-message-broker/automotive-message-broker_git.bb
@@ -19,6 +19,8 @@ SRC_URI += "file://amb_allow_sessionbus.patch \
             file://ambd.service \
             "
 
+EXTRA_OECMAKE += "-Denable_icecc=OFF"
+
 SYSTEMD_PACKAGES = "${PN}"
 SYSTEMD_SERVICE_${PN} = "ambd.service"
 


### PR DESCRIPTION
Building on a host which has icecc will cause it to pull in host libs, this fixes that by disabling the check for icecc.
