### PR TITLE
Update meta-raspberrypi to avoid taskhash mismatch error

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ URI: git://github.com/joaohf/meta-erlang.git
 
 URI: git://git.yoctoproject.org/meta-raspberrypi
 * branch:   master
-* revision: 2745399f75d7564fcc586d0365ff73be47849d0e
+* revision: 4c02c7ce07121c2f5367204445f93199d828bb10
 
 ## The Renesas R-Car Gen2 Koelsch & Porter boards depend in addition on: ##
 URI: git://github.com/slawr/meta-renesas.git


### PR DESCRIPTION
```
    [GDP-375] the commit reference there appears to solve this
    recurring issue. Fixing README.md
```
