### PR TITLE
audiomanager: Temporarily use audiomanager & audiomanagerplugins 7.0

### DIFF
--- a/meta-genivi-dev/recipes-multimedia/audiomanager/audiomanager/0001-audiomanager-fix-lib-install-path-for-multilib.patch
+++ b/meta-genivi-dev/recipes-multimedia/audiomanager/audiomanager/0001-audiomanager-fix-lib-install-path-for-multilib.patch
@@ -1,0 +1,60 @@
+From d214197c418945f8ae8ad72a7173c6b83a808ef0 Mon Sep 17 00:00:00 2001
+From: Clement Dransart <clement.dransart@awtce.be>
+Date: Fri, 17 Jun 2016 10:40:36 +0200
+Subject: [audiomanager][PATCH] audiomanager: fix lib install path for multilib
+
+Signed-off-by: Clement Dransart <clement.dransart@awtce.be>
+---
+ CMakeLists.txt | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d4e3cb5..0004b07 100755
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -169,13 +169,13 @@ if(USE_BUILD_LIBS)
+ 	endif(NOT DEFINED CONTROLLER_PLUGIN)
+ else(USE_BUILD_LIBS)
+ 	if(NOT DEFINED DEFAULT_PLUGIN_COMMAND_DIR)
+-		set(DEFAULT_PLUGIN_COMMAND_DIR "${CMAKE_INSTALL_PREFIX}/lib/${LIB_INSTALL_SUFFIX}/command")
++		set(DEFAULT_PLUGIN_COMMAND_DIR "${CMAKE_INSTALL_LIBDIR}/command")
+ 	endif(NOT DEFINED DEFAULT_PLUGIN_COMMAND_DIR)
+ 	if(NOT DEFINED DEFAULT_PLUGIN_ROUTING_DIR)
+-		set(DEFAULT_PLUGIN_ROUTING_DIR "${CMAKE_INSTALL_PREFIX}/lib/${LIB_INSTALL_SUFFIX}/routing")
++		set(DEFAULT_PLUGIN_ROUTING_DIR "${CMAKE_INSTALL_LIBDIR}/routing")
+ 	endif(NOT DEFINED DEFAULT_PLUGIN_ROUTING_DIR)
+ 	if(NOT DEFINED CONTROLLER_PLUGIN)
+-		set(CONTROLLER_PLUGIN "${CMAKE_INSTALL_PREFIX}/lib/${LIB_INSTALL_SUFFIX}/control/libPluginControlInterface.so")
++		set(CONTROLLER_PLUGIN "${CMAKE_INSTALL_LIBDIR}/control/libPluginControlInterface.so")
+ 	endif(NOT DEFINED CONTROLLER_PLUGIN)
+ endif(USE_BUILD_LIBS)
+ 
+@@ -228,7 +228,7 @@ set (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -O2 -DNDEBUG")
+ 
+ configure_package_config_file ( 
+     ${CMAKE_SOURCE_DIR}/cmake/audiomanagerConfig.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/audiomanagerConfig.cmake
+-    INSTALL_DESTINATION lib/${LIB_INSTALL_SUFFIX}/cmake
++    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
+     PATH_VARS AUDIO_INCLUDE_FOLDER )
+                               
+ write_basic_package_version_file(
+@@ -237,14 +237,14 @@ write_basic_package_version_file(
+     COMPATIBILITY SameMajorVersion )
+                           
+ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/audiomanagerConfig.cmake 
+-    DESTINATION lib/${LIB_INSTALL_SUFFIX}/cmake
++    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
+     COMPONENT dev)    
+ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/config.h 
+     DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${LIB_INSTALL_SUFFIX}
+     COMPONENT dev)
+     
+ configure_file( ${CMAKE_SOURCE_DIR}/cmake/audiomanager.pc.in ${CMAKE_BINARY_DIR}/audiomanager.pc @ONLY )
+-install(FILES ${CMAKE_BINARY_DIR}/audiomanager.pc DESTINATION lib/pkgconfig COMPONENT devel)    
++install(FILES ${CMAKE_BINARY_DIR}/audiomanager.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig COMPONENT devel)
+ 
+ add_subdirectory (AudioManagerDaemon)
+ 
+-- 
+1.9.1
+

--- a/meta-genivi-dev/recipes-multimedia/audiomanager/audiomanager/AudioManager.service
+++ b/meta-genivi-dev/recipes-multimedia/audiomanager/audiomanager/AudioManager.service
@@ -1,0 +1,16 @@
+# Copyright (c) 2012 Wind River Systems, Inc.
+# AudioManager systemd service file
+
+[Unit]
+Description=AudioManager
+Requires=dbus.service
+After=dbus.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/lib/systemd/scripts/setup_amgr.sh
+
+[Install]
+WantedBy=multi-user.target
+

--- a/meta-genivi-dev/recipes-multimedia/audiomanager/audiomanager/setup_amgr.sh
+++ b/meta-genivi-dev/recipes-multimedia/audiomanager/audiomanager/setup_amgr.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+rm /tmp/session_amgr
+dbus-daemon --session --print-address --fork > /tmp/session_amgr
+export DBUS_SESSION_BUS_ADDRESS=`cat /tmp/session_amgr`
+AudioManager -d
+

--- a/meta-genivi-dev/recipes-multimedia/audiomanager/audiomanager_7.0.bb
+++ b/meta-genivi-dev/recipes-multimedia/audiomanager/audiomanager_7.0.bb
@@ -1,0 +1,67 @@
+SUMMARY = "Genivi AudioManager"
+HOMEPAGE = "https://www.genivi.org/"
+SECTION = "multimedia"
+
+LICENSE = "MPLv2"
+LIC_FILES_CHKSUM = "file://LICENCE;md5=f164349b56ed530a6642e9b9f244eec5"
+PR = "r1"
+
+DEPENDS = "common-api-c++-dbus dlt-daemon sqlite3 dbus node-state-manager"
+
+SRCREV = "8725157e248c6706de59a02996f869b6ccdccb13"
+SRC_URI = " \
+    git://git.projects.genivi.org/AudioManager.git;branch=master;protocol=http \
+    file://AudioManager.service \
+    file://setup_amgr.sh \
+    file://0001-audiomanager-fix-lib-install-path-for-multilib.patch \
+    "
+S = "${WORKDIR}/git"
+
+inherit cmake pkgconfig systemd
+
+SYSTEMD_PACKAGES = "${PN}"
+SYSTEMD_SERVICE_${PN} = "AudioManager.service"
+SYSTEMD_AUTO_ENABLE = "disable"
+
+OECMAKE_CXX_FLAGS +="-ldl"
+EXTRA_OECMAKE = " -DWITH_TESTS=OFF"
+
+FILES_${PN} = " \
+    ${bindir}/* \
+    ${systemd_unitdir}/AudioManager.service \
+    ${systemd_unitdir}/scripts/setup_amgr.sh \
+    "
+FILES_${PN}-dev += " \
+    ${libdir}/* \
+    /usr/share/cmake/Modules/* \
+    "
+do_install_append() {
+    if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
+        mkdir -p ${D}${systemd_unitdir}/scripts/
+        install -m 0755 ${WORKDIR}/setup_amgr.sh ${D}${systemd_unitdir}/scripts/setup_amgr.sh
+        install -d ${D}${systemd_unitdir}/system/
+        install -m 0644 ${WORKDIR}/AudioManager.service ${D}${systemd_unitdir}/system
+    fi
+
+    install -d 0755 ${D}/usr/share/cmake/Modules
+    for i in `ls ${S}/cmake/*.cmake`; do
+        install -m 0644 ${i} ${D}/usr/share/cmake/Modules
+    done
+    perl -pi -e 's|COMMAND find "/usr/local/share/CommonAPI-\${CommonAPI_VERSION}"|COMMAND find "${PSEUDO_PREFIX}/share"|' \
+      ${D}/usr/share/cmake/Modules/CommonAPI.cmake
+
+    C_CMAKE=${D}${libdir}/cmake/audiomanagerConfig.cmake
+    perl -pi -e 's|;${S}/cmake||' ${C_CMAKE}
+    perl -pi -e 's|;(.*)/usr/share/cmake/Modules/||' ${C_CMAKE}
+    perl -pi -e 's|set\(WITH_TESTS|#set\(WITH_TESTS|' ${C_CMAKE}
+    perl -pi -e 's|.*set_and_check\(GOOGLE_MOCK_PROJECT_FOLDER \"(.+)\"\)\n||' ${C_CMAKE}
+    perl -pi -e 's|GOOGLE_TEST_INCLUDE_DIR \"(.+)\"|GOOGLE_TEST_INCLUDE_DIR \"${PKG_CONFIG_SYSROOT_DIR}/usr/include/gtest\"|' ${C_CMAKE}
+    perl -pi -e 's|GMOCK_INCLUDE_DIR \"(.+)\"|GMOCK_INCLUDE_DIR \"${PKG_CONFIG_SYSROOT_DIR}/usr/include/gmock\"|' ${C_CMAKE}
+#   perl -pi -e \
+#     's/set_and_check\(CMAKE_MODULE_PATH/#set_and_check\(CMAKE_MODULE_PATH/' \
+#     ${D}${libdir}/cmake/audiomanagerConfig.cmake
+}
+
+python do_qa_staging() {
+    bb.note("QA checking staging - SKIP")
+}

--- a/meta-genivi-dev/recipes-multimedia/audiomanager/audiomanagerplugins/build-fixup.patch
+++ b/meta-genivi-dev/recipes-multimedia/audiomanager/audiomanagerplugins/build-fixup.patch
@@ -1,0 +1,245 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index aa885e5..70313f7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -54,7 +54,7 @@ IF(WITH_ROUTING_INTERFACE_CAPI)
+ ENDIF(WITH_ROUTING_INTERFACE_CAPI)
+ 
+ IF(WITH_ROUTING_INTERFACE_DBUS) 
+-		add_subdirectory(PluginRoutingInterfaceDbus)
++		add_subdirectory(PluginRoutingInterfaceDBus)
+ ENDIF(WITH_ROUTING_INTERFACE_DBUS) 
+         
+ add_custom_target(plugins-install
+diff --git a/PluginCommandInterfaceCAPI/cmake/FindAudioManager.cmake b/PluginCommandInterfaceCAPI/cmake/FindAudioManager.cmake
+index ad97f23..f1dd343 100644
+--- a/PluginCommandInterfaceCAPI/cmake/FindAudioManager.cmake
++++ b/PluginCommandInterfaceCAPI/cmake/FindAudioManager.cmake
+@@ -1,6 +1,6 @@
+ find_path(AUDIOMANAGER_CMAKE_CONFIG_PATH 
+                  audiomanagerConfig.cmake
+-                 PATH_SUFFIXES audiomanager/cmake
++                 PATH_SUFFIXES cmake
+                  PATHS
+                  ${CMAKE_INSTALL_PATH}
+                  "${CMAKE_INSTALL_PREFIX}/lib"
+diff --git a/PluginCommandInterfaceCAPI/include/CAmCommandSenderCommon.h b/PluginCommandInterfaceCAPI/include/CAmCommandSenderCommon.h
+index 74af7ae..a12e65f 100644
+--- a/PluginCommandInterfaceCAPI/include/CAmCommandSenderCommon.h
++++ b/PluginCommandInterfaceCAPI/include/CAmCommandSenderCommon.h
+@@ -20,11 +20,11 @@
+ 
+ #include <memory>
+ #include "audiomanagertypes.h"
+-#include <v1_0/org/genivi/am/audiomanagertypes/__Anonymous__.hpp>
++#include <v1/org/genivi/am/audiomanagertypes/__Anonymous__.hpp>
+ 
+ using namespace am;
+ 
+-#define  am_types v1_0::org::genivi::am::audiomanagertypes::__Anonymous__
++#define  am_types v1::org::genivi::am::audiomanagertypes::__Anonymous__
+ 
+ /**
+  * The following functions convert the basics AudiomManager types from/to CommonAPI types.
+diff --git a/PluginCommandInterfaceCAPI/include/CAmCommandSenderService.h b/PluginCommandInterfaceCAPI/include/CAmCommandSenderService.h
+index 70c1397..73bad65 100644
+--- a/PluginCommandInterfaceCAPI/include/CAmCommandSenderService.h
++++ b/PluginCommandInterfaceCAPI/include/CAmCommandSenderService.h
+@@ -18,7 +18,7 @@
+ #ifndef CAMCOMMANDSENDERSERVICE_H_
+ #define CAMCOMMANDSENDERSERVICE_H_
+ 
+-#include <v1_0/org/genivi/am/commandinterface/CommandControlStubDefault.hpp>
++#include <v1/org/genivi/am/commandinterface/CommandControlStubDefault.hpp>
+ #include "CAmCommandSenderCommon.h"
+ #include "IAmCommand.h"
+ 
+@@ -30,7 +30,7 @@ namespace am {
+ /**
+  * A concrete stub implementation used by the command sender plug-in.
+  */
+-class CAmCommandSenderService: public v1_0::org::genivi::am::commandinterface::CommandControlStubDefault {
++class CAmCommandSenderService: public v1::org::genivi::am::commandinterface::CommandControlStubDefault {
+ 	IAmCommandReceive* mpIAmCommandReceive;
+ public:
+ 	CAmCommandSenderService();
+diff --git a/PluginCommandInterfaceCAPI/test/CAmCommandSenderCAPITest.h b/PluginCommandInterfaceCAPI/test/CAmCommandSenderCAPITest.h
+index 1479d85..1c72fac 100644
+--- a/PluginCommandInterfaceCAPI/test/CAmCommandSenderCAPITest.h
++++ b/PluginCommandInterfaceCAPI/test/CAmCommandSenderCAPITest.h
+@@ -24,10 +24,10 @@
+ #include "CAmTestCAPIWrapper.h"
+ #include "../include/CAmCommandSenderCAPI.h"
+ #include "MockIAmCommandReceive.h"
+-#include <v1_0/org/genivi/am/commandinterface/CommandControlProxy.hpp>
++#include <v1/org/genivi/am/commandinterface/CommandControlProxy.hpp>
+ 
+ #define UNIT_TEST 1
+-#define am_commandcontrol v1_0::org::genivi::am::commandinterface
++#define am_commandcontrol v1::org::genivi::am::commandinterface
+ 
+ using namespace testing;
+ 
+diff --git a/PluginCommandInterfaceCAPI/test/MockNotificationsClient.h b/PluginCommandInterfaceCAPI/test/MockNotificationsClient.h
+index ea9f904..d716a2b 100644
+--- a/PluginCommandInterfaceCAPI/test/MockNotificationsClient.h
++++ b/PluginCommandInterfaceCAPI/test/MockNotificationsClient.h
+@@ -22,7 +22,7 @@
+ #include "gtest/gtest.h"
+ #include "gmock/gmock.h"
+ #include "../include/CAmCommandSenderCommon.h"
+-#include <v1_0/org/genivi/am/commandinterface/CommandControlProxy.hpp>
++#include <v1/org/genivi/am/commandinterface/CommandControlProxy.hpp>
+ 
+ 
+ namespace am {
+diff --git a/PluginCommandInterfaceDbus/cmake/FindAudioManager.cmake b/PluginCommandInterfaceDbus/cmake/FindAudioManager.cmake
+index ad97f23..f1dd343 100644
+--- a/PluginCommandInterfaceDbus/cmake/FindAudioManager.cmake
++++ b/PluginCommandInterfaceDbus/cmake/FindAudioManager.cmake
+@@ -1,6 +1,6 @@
+ find_path(AUDIOMANAGER_CMAKE_CONFIG_PATH 
+                  audiomanagerConfig.cmake
+-                 PATH_SUFFIXES audiomanager/cmake
++                 PATH_SUFFIXES cmake
+                  PATHS
+                  ${CMAKE_INSTALL_PATH}
+                  "${CMAKE_INSTALL_PREFIX}/lib"
+diff --git a/PluginControlInterface/cmake/FindAudioManager.cmake b/PluginControlInterface/cmake/FindAudioManager.cmake
+index ad97f23..f1dd343 100644
+--- a/PluginControlInterface/cmake/FindAudioManager.cmake
++++ b/PluginControlInterface/cmake/FindAudioManager.cmake
+@@ -1,6 +1,6 @@
+ find_path(AUDIOMANAGER_CMAKE_CONFIG_PATH 
+                  audiomanagerConfig.cmake
+-                 PATH_SUFFIXES audiomanager/cmake
++                 PATH_SUFFIXES cmake
+                  PATHS
+                  ${CMAKE_INSTALL_PATH}
+                  "${CMAKE_INSTALL_PREFIX}/lib"
+diff --git a/PluginRoutingInterfaceAsync/cmake/FindAudioManager.cmake b/PluginRoutingInterfaceAsync/cmake/FindAudioManager.cmake
+index ad97f23..f1dd343 100644
+--- a/PluginRoutingInterfaceAsync/cmake/FindAudioManager.cmake
++++ b/PluginRoutingInterfaceAsync/cmake/FindAudioManager.cmake
+@@ -1,6 +1,6 @@
+ find_path(AUDIOMANAGER_CMAKE_CONFIG_PATH 
+                  audiomanagerConfig.cmake
+-                 PATH_SUFFIXES audiomanager/cmake
++                 PATH_SUFFIXES cmake
+                  PATHS
+                  ${CMAKE_INSTALL_PATH}
+                  "${CMAKE_INSTALL_PREFIX}/lib"
+diff --git a/PluginRoutingInterfaceCAPI/cmake/FindAudioManager.cmake b/PluginRoutingInterfaceCAPI/cmake/FindAudioManager.cmake
+index ad97f23..f1dd343 100644
+--- a/PluginRoutingInterfaceCAPI/cmake/FindAudioManager.cmake
++++ b/PluginRoutingInterfaceCAPI/cmake/FindAudioManager.cmake
+@@ -1,6 +1,6 @@
+ find_path(AUDIOMANAGER_CMAKE_CONFIG_PATH 
+                  audiomanagerConfig.cmake
+-                 PATH_SUFFIXES audiomanager/cmake
++                 PATH_SUFFIXES cmake
+                  PATHS
+                  ${CMAKE_INSTALL_PATH}
+                  "${CMAKE_INSTALL_PREFIX}/lib"
+diff --git a/PluginRoutingInterfaceCAPI/include/CAmLookupData.h b/PluginRoutingInterfaceCAPI/include/CAmLookupData.h
+index 773271f..6c1cd8d 100644
+--- a/PluginRoutingInterfaceCAPI/include/CAmLookupData.h
++++ b/PluginRoutingInterfaceCAPI/include/CAmLookupData.h
+@@ -25,7 +25,7 @@
+ #include "audiomanagertypes.h"
+ #include "IAmRouting.h"
+ #include "CAmRoutingSenderCommon.h"
+-#include <v0_1/org/genivi/am/routinginterface/RoutingControlProxy.hpp>
++#include <v0/org/genivi/am/routinginterface/RoutingControlProxy.hpp>
+ 
+ #ifdef UNIT_TEST
+ #include "../test/IAmRoutingSenderBackdoor.h" //we need this for the unit test
+diff --git a/PluginRoutingInterfaceCAPI/include/CAmRoutingSenderCommon.h b/PluginRoutingInterfaceCAPI/include/CAmRoutingSenderCommon.h
+index c7399b6..faf6687 100644
+--- a/PluginRoutingInterfaceCAPI/include/CAmRoutingSenderCommon.h
++++ b/PluginRoutingInterfaceCAPI/include/CAmRoutingSenderCommon.h
+@@ -20,12 +20,12 @@
+ 
+ #include <memory>
+ #include "audiomanagertypes.h"
+-#include <v1_0/org/genivi/am/audiomanagertypes/__Anonymous__.hpp>
++#include <v1/org/genivi/am/audiomanagertypes/__Anonymous__.hpp>
+ 
+ using namespace am;
+ 
+-#define am_types v1_0::org::genivi::am::audiomanagertypes::__Anonymous__
+-#define am_routing_interface v0_1::org::genivi::am::routinginterface
++#define am_types v1::org::genivi::am::audiomanagertypes::__Anonymous__
++#define am_routing_interface v0::org::genivi::am::routinginterface
+ 
+ /**
+  * Utility functions
+diff --git a/PluginRoutingInterfaceCAPI/include/CAmRoutingService.h b/PluginRoutingInterfaceCAPI/include/CAmRoutingService.h
+index b545d8d..9a95111 100644
+--- a/PluginRoutingInterfaceCAPI/include/CAmRoutingService.h
++++ b/PluginRoutingInterfaceCAPI/include/CAmRoutingService.h
+@@ -19,7 +19,7 @@
+ #define CAMROUTINGSERVICE_H_
+ 
+ 
+-#include <v0_1/org/genivi/am/routinginterface/RoutingControlObserverStubDefault.hpp>
++#include <v0/org/genivi/am/routinginterface/RoutingControlObserverStubDefault.hpp>
+ #include "IAmRouting.h"
+ #include "CAmCommonAPIWrapper.h"
+ #include "CAmLookupData.h"
+diff --git a/PluginRoutingInterfaceCAPI/test/CAmRoutingInterfaceCAPITests.h b/PluginRoutingInterfaceCAPI/test/CAmRoutingInterfaceCAPITests.h
+index a3ea056..a000fe5 100644
+--- a/PluginRoutingInterfaceCAPI/test/CAmRoutingInterfaceCAPITests.h
++++ b/PluginRoutingInterfaceCAPI/test/CAmRoutingInterfaceCAPITests.h
+@@ -29,8 +29,8 @@
+ #include "../include/CAmRoutingSenderCommon.h"
+ #include "../include/CAmRoutingSenderCAPI.h"
+ #include "MockIAmRoutingReceive.h"
+-#include <v0_1/org/genivi/am/routinginterface/RoutingControlObserverProxy.hpp>
+-#include <v0_1/org/genivi/am/routinginterface/RoutingControlProxy.hpp>
++#include <v0/org/genivi/am/routinginterface/RoutingControlObserverProxy.hpp>
++#include <v0/org/genivi/am/routinginterface/RoutingControlProxy.hpp>
+ 
+ using namespace testing;
+ 
+diff --git a/PluginRoutingInterfaceCAPI/test/CAmTestRoutingSenderService.h b/PluginRoutingInterfaceCAPI/test/CAmTestRoutingSenderService.h
+index ce4c27a..08e462d 100644
+--- a/PluginRoutingInterfaceCAPI/test/CAmTestRoutingSenderService.h
++++ b/PluginRoutingInterfaceCAPI/test/CAmTestRoutingSenderService.h
+@@ -20,9 +20,9 @@
+ 
+ #include "audiomanagertypes.h"
+ #include "../include/CAmRoutingSenderCommon.h"
+-#include <v0_1/org/genivi/am/routinginterface/RoutingControlStubDefault.hpp>
+-#include <v0_1/org/genivi/am/routinginterface/RoutingControlObserverProxy.hpp>
+-#include <v0_1/org/genivi/am/routinginterface/RoutingControlProxy.hpp>
++#include <v0/org/genivi/am/routinginterface/RoutingControlStubDefault.hpp>
++#include <v0/org/genivi/am/routinginterface/RoutingControlObserverProxy.hpp>
++#include <v0/org/genivi/am/routinginterface/RoutingControlProxy.hpp>
+ 
+ 
+ namespace am {
+diff --git a/PluginRoutingInterfaceDBus/cmake/FindAudioManager.cmake b/PluginRoutingInterfaceDBus/cmake/FindAudioManager.cmake
+index ad97f23..f1dd343 100644
+--- a/PluginRoutingInterfaceDBus/cmake/FindAudioManager.cmake
++++ b/PluginRoutingInterfaceDBus/cmake/FindAudioManager.cmake
+@@ -1,6 +1,6 @@
+ find_path(AUDIOMANAGER_CMAKE_CONFIG_PATH 
+                  audiomanagerConfig.cmake
+-                 PATH_SUFFIXES audiomanager/cmake
++                 PATH_SUFFIXES cmake
+                  PATHS
+                  ${CMAKE_INSTALL_PATH}
+                  "${CMAKE_INSTALL_PREFIX}/lib"
+diff --git a/cmake/FindAudioManager.cmake b/cmake/FindAudioManager.cmake
+index ad97f23..f1dd343 100755
+--- a/cmake/FindAudioManager.cmake
++++ b/cmake/FindAudioManager.cmake
+@@ -1,6 +1,6 @@
+ find_path(AUDIOMANAGER_CMAKE_CONFIG_PATH 
+                  audiomanagerConfig.cmake
+-                 PATH_SUFFIXES audiomanager/cmake
++                 PATH_SUFFIXES cmake
+                  PATHS
+                  ${CMAKE_INSTALL_PATH}
+                  "${CMAKE_INSTALL_PREFIX}/lib"

--- a/meta-genivi-dev/recipes-multimedia/audiomanager/audiomanagerplugins_7.0.bb
+++ b/meta-genivi-dev/recipes-multimedia/audiomanager/audiomanagerplugins_7.0.bb
@@ -1,0 +1,33 @@
+SUMMARY = "Genivi AudioManager Plugins"
+HOMEPAGE = "https://www.genivi.org/"
+SECTION = "multimedia"
+
+LICENSE = "MPL-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7f619bab123dad"
+
+DEPENDS = "audiomanager capicxx-core-native capicxx-dbus-native"
+
+SRCREV = "a0ed3b8f05147e9240d941655488d505057bbae7"
+SRC_URI = " \
+    git://git.projects.genivi.org/AudioManagerPlugins.git;branch=master;protocol=http \
+    file://build-fixup.patch \
+    "
+S = "${WORKDIR}/git"
+
+inherit cmake
+
+EXTRA_OECMAKE = " -DWITH_TESTS=OFF \
+    -DWITH_COMMAND_INTERFACE_COMMON_CAPI=ON -DWITH_COMMAND_INTERFACE_DBUS=ON \
+    -DWITH_ROUTING_INTERFACE_CAPI=ON -DWITH_ROUTING_INTERFACE_DBUS=ON \
+    -DWITH_ROUTING_INTERFACE_ASYNC=ON \
+    "
+
+FILES_${PN} += " \
+    ${libdir}/* \
+    /usr/share/* \
+    "
+
+do_install_append() {
+    mv ${D}${libdir}/audiomanager/* ${D}${libdir}
+    rmdir ${D}${libdir}/audiomanager
+}


### PR DESCRIPTION
meta-ivi 11.0 upgrades audiomanager to 7.4 which brings compatibility
issues with the pulseaudio plugin patches carried in meta-genivi-dev.
Until audiomanagerplugins7.4 is working correctly, 7.0 recipes from
meta-ivi will be used.
