### PR TITLE
qtimageformats: Add libwebp for dragonboard

### DIFF
--- a/meta-genivi-dev/recipes-qt/qt5/qtimageformats_%.bbappend
+++ b/meta-genivi-dev/recipes-qt/qt5/qtimageformats_%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG_append_dragonboard-410c = " libwebp"


### PR DESCRIPTION
[GDP-438] GDP SDK build fails for Dragonboard

Signed-off-by: Changhyeok Bae changhyeok.bae@gmail.com
