### PR TITLE
Add patch so that fmradio builds

### DIFF
--- a/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/fmradio.bb
+++ b/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/fmradio.bb
@@ -1,13 +1,17 @@
 # Copyright (C) 2015-2016 GENIVI Alliance
+# Released under the MIT license (see COPYING.MIT for the terms)
 
 LICENSE  = "MPL-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=815ca599c9df247a0c7f619bab123dad"
-SRC_URI = "git://github.com/RobertAJMarshall/FMRadio"
-SRCREV  = "257a1f0d6ab4a83c0588051ca6aaba22c9bf63b6"
+SRC_URI = "git://github.com/GENIVI/FMRadio"
+SRCREV  = "8da331f78fdca7a98f5b812c9f40231c868ed8f3"
 
 SUMMARY = "FM Radio"
 DEPENDS = "qtbase qtdeclarative"
 
+SRC_URI_append ="\
+    file://0001-fmradio-remove-absolute-include-path.patch \
+    "
 
 S = "${WORKDIR}/git"
 

--- a/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/fmradio/0001-fmradio-remove-absolute-include-path.patch
+++ b/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/fmradio/0001-fmradio-remove-absolute-include-path.patch
@@ -1,0 +1,13 @@
+Index: git/fm-radio-app.pro
+===================================================================
+--- git/fm-radio-app.pro
++++ git/fm-radio-app.pro
+@@ -5,8 +5,6 @@ CONFIG += c++11
+ 
+ SOURCES += main.cpp
+ 
+-INCLUDEPATH += /usr/include
+-
+ target.path = /usr/bin
+ 
+ RESOURCES += qml.qrc


### PR DESCRIPTION
[GDP-411] the ICS .pro file uses /usr/include, this patch removes that path
and restores the GENIVI version of the repository.

Also fixed the licence comment in the recipe.