### PR TITLE
weston: Launch DRM backend without input devices

### DIFF
--- a/meta-genivi-dev/recipes-graphics/wayland/weston/0001-compositor-drm.c-Launch-without-input-devices.patch
+++ b/meta-genivi-dev/recipes-graphics/wayland/weston/0001-compositor-drm.c-Launch-without-input-devices.patch
@@ -1,0 +1,29 @@
+From 43f66e20a6788388df4fc052d257f005c359080f Mon Sep 17 00:00:00 2001
+From: Leon Anavi <leon.anavi@konsulko.com>
+Date: Wed, 14 Dec 2016 12:26:31 +0200
+Subject: [PATCH] compositor-drm.c: Launch without input devices
+
+Launch Weston 11 even if input devices (such as
+a keyboard, a mouse or a touchscreen) are not
+present.
+
+Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>
+---
+ src/compositor-drm.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/src/compositor-drm.c b/src/compositor-drm.c
+index fd89627..f66e0af 100644
+--- a/src/compositor-drm.c
++++ b/src/compositor-drm.c
+@@ -3123,7 +3123,6 @@ drm_backend_create(struct weston_compositor *compositor,
+ 	if (udev_input_init(&b->input,
+ 			    compositor, b->udev, seat_id) < 0) {
+ 		weston_log("failed to create input devices\n");
+-		goto err_sprite;
+ 	}
+ 
+ 	if (create_outputs(b, config->connector, drm_device) < 0) {
+-- 
+2.7.4
+

--- a/meta-genivi-dev/recipes-graphics/wayland/weston_1.%.bbappend
+++ b/meta-genivi-dev/recipes-graphics/wayland/weston_1.%.bbappend
@@ -8,6 +8,7 @@ SRC_URI_append = "\
     file://start_am-poc.sh \
     file://start_browser-poc.sh \
     file://weston.ini \
+    file://0001-compositor-drm.c-Launch-without-input-devices.patch \
 "
 
 inherit systemd


### PR DESCRIPTION
Allow launching Weston 1.11 with DRM backend even
without input devices such as a keyboard, a mouse
or a touchscreen. This fix is convenient for
demonstrations and it is useful for Raspberry Pi
2 and 3 as well as other devices which rely on
DRM backend.

[GDP-149] Weston and HMI apps are not launched
without input devices on Raspberry Pi

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>