### PR TITLE
Chromium integration

### DIFF
--- a/meta-genivi-dev/recipes-dev-platform/packagegroups/packagegroup-gdp-browser.bb
+++ b/meta-genivi-dev/recipes-dev-platform/packagegroups/packagegroup-gdp-browser.bb
@@ -16,4 +16,5 @@ ALLOW_EMPTY_${PN} = "1"
 RDEPENDS_${PN} += "\
     browser-poc \
     genivi-browser-test-hmi-precompiled \
+    chromium-wayland \
     "

--- a/meta-genivi-dev/recipes-extended/chromium/chromium-wayland/0001-seccomp-bpf-Allow-MADV_FREE-in-madvise-2.patch
+++ b/meta-genivi-dev/recipes-extended/chromium/chromium-wayland/0001-seccomp-bpf-Allow-MADV_FREE-in-madvise-2.patch
@@ -1,0 +1,50 @@
+From 65180d3bfbec6fb3d0ed2ca7961094fb38452832 Mon Sep 17 00:00:00 2001
+From: "raphael.kubo.da.costa" <raphael.kubo.da.costa@intel.com>
+Date: Wed, 9 Nov 2016 09:46:13 -0800
+Subject: [PATCH] seccomp-bpf: Allow MADV_FREE in madvise(2)
+
+The seccomp filter was assuming MADV_DONTNEED and MADV_FREE were the
+same thing, but they are not. In particular, a separate MADV_FREE macro
+was introduced in Linux 4.5, and glibc started defining it in its
+headers since 2.24 with this commit:
+
+https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=981569c74cbb6bafa2ddcefa6dd9dbdc938ff1c8
+
+Blink's PageAllocator.cpp sets MADV_FREE to MADV_DONTNEED if the former
+is not defined as a macro. On systems with glibc >= 2.24, this no longer
+happens and MADV_FREE will be rejected by the madvise seccomp filter,
+leading to a crash in Blink's decommitSystemPages().
+
+R=jln@chromium.org,jorgelo@chromium.org,mdempsky@chromium.org,rickyz@chromium.org
+
+Review-Url: https://codereview.chromium.org/2490893002
+Cr-Commit-Position: refs/heads/master@{#430965}
+---
+ sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc b/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc
+index af47269..88a9326 100644
+--- a/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc
++++ b/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc
+@@ -174,9 +174,15 @@ ResultExpr EvaluateSyscallImpl(int fs_denied_errno,
+   }
+ 
+   if (sysno == __NR_madvise) {
+-    // Only allow MADV_DONTNEED (aka MADV_FREE).
++    // Only allow MADV_DONTNEED and MADV_FREE.
+     const Arg<int> advice(2);
+-    return If(advice == MADV_DONTNEED, Allow()).Else(Error(EPERM));
++    return If(AnyOf(advice == MADV_DONTNEED
++#if defined(MADV_FREE)
++                    // MADV_FREE was introduced in Linux 4.5 and started being
++                    // defined in glibc 2.24.
++                    , advice == MADV_FREE
++#endif
++                    ), Allow()).Else(Error(EPERM));
+   }
+ 
+ #if defined(__i386__) || defined(__x86_64__) || defined(__mips__) || \
+-- 
+2.7.4
+

--- a/meta-genivi-dev/recipes-extended/chromium/chromium-wayland/armv7ve/include.gypi
+++ b/meta-genivi-dev/recipes-extended/chromium/chromium-wayland/armv7ve/include.gypi
@@ -1,0 +1,9 @@
+{
+  'variables': {
+    # Configure for armv7 compilation
+    'target_arch': 'arm',
+    'armv7': 1,
+    'arm_thumb': 1,
+    'arm_neon': 1,
+  }, 
+}

--- a/meta-genivi-dev/recipes-extended/chromium/chromium-wayland/armv7ve/oe-defaults.gypi
+++ b/meta-genivi-dev/recipes-extended/chromium/chromium-wayland/armv7ve/oe-defaults.gypi
@@ -1,0 +1,15 @@
+{
+  'variables': {
+    'use_system_bzip2': 1,
+    'disable_nacl': 1,
+    'proprietary_codecs': 1,
+    'v8_use_snapshot': 1,
+    'use_system_ffmpeg': 0,
+    'linux_use_tcmalloc': 0,
+    'linux_link_kerberos': 0,
+    'use_kerberos': 0,
+    'use_cups': 0,
+    'use_gnome_keyring': 0,
+    'linux_link_gnome_keyring': 0
+  }, 
+}

--- a/meta-genivi-dev/recipes-extended/chromium/chromium-wayland/google-chrome.desktop
+++ b/meta-genivi-dev/recipes-extended/chromium/chromium-wayland/google-chrome.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=Chromium browser
+Type=Application
+Icon=file:///usr/bin/chromium/product_logo_128.png
+Exec=/usr/bin/google-chrome

--- a/meta-genivi-dev/recipes-extended/chromium/chromium-wayland_%.bbappend
+++ b/meta-genivi-dev/recipes-extended/chromium/chromium-wayland_%.bbappend
@@ -1,6 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 SRC_URI += "\
+    file://0001-seccomp-bpf-Allow-MADV_FREE-in-madvise-2.patch \
     file://google-chrome.desktop \
 "
 

--- a/meta-genivi-dev/recipes-extended/chromium/chromium-wayland_%.bbappend
+++ b/meta-genivi-dev/recipes-extended/chromium/chromium-wayland_%.bbappend
@@ -16,3 +16,13 @@ do_install_append() {
             ${D}${bindir}/${BPN}/product_logo_$size.png
     done
 }
+
+# Raspberry Pi workarounds
+
+COMPATIBLE_MACHINE_armv7ve = "(.*)"
+
+# Apply same TUNE_FEATURES as in an armv7a build
+ARMFPABI_armv7ve = "${@bb.utils.contains('TUNE_FEATURES', 'callconvention-hard', 'arm_float_abi=hard', 'arm_float_abi=softfp', d)}"
+
+# Remove cortexa7 optimization that conflicts with Chromium's hardcoded ARM flags
+TUNE_FEATURES_remove_armv7ve = "cortexa7"

--- a/meta-genivi-dev/recipes-extended/chromium/chromium-wayland_%.bbappend
+++ b/meta-genivi-dev/recipes-extended/chromium/chromium-wayland_%.bbappend
@@ -1,0 +1,15 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "\
+    file://google-chrome.desktop \
+"
+
+do_install_append() {
+    install -d ${D}${datadir}/applications/
+    install -m 0444 ${WORKDIR}/google-chrome.desktop ${D}${datadir}/applications/
+
+    for size in 22 24 48 64 128 256; do
+        install -Dm 0644 ${S}/chrome/app/theme/chromium/product_logo_$size.png \
+            ${D}${bindir}/${BPN}/product_logo_$size.png
+    done
+}

--- a/meta-genivi-dev/recipes-extended/chromium/chromium-wayland_%.bbappend
+++ b/meta-genivi-dev/recipes-extended/chromium/chromium-wayland_%.bbappend
@@ -4,6 +4,9 @@ SRC_URI += "\
     file://google-chrome.desktop \
 "
 
+# FIXME: workaround for https://at.projects.genivi.org/jira/browse/LM-2
+CHROMIUM_EXTRA_ARGS_append = " --window-size=1728,1080"
+
 do_install_append() {
     install -d ${D}${datadir}/applications/
     install -m 0444 ${WORKDIR}/google-chrome.desktop ${D}${datadir}/applications/


### PR DESCRIPTION
These patches add the required files to integrate Chromium with the GENIVI HMI and append some rules to the chromium recipe to workaround a couple of issues with the window aspect ratio and the icon.

Depends on the [meta-browser layer](https://github.com/OSSystems/meta-browser), which needs to be added as a submodule to [genivi-dev-platform](https://github.com/GENIVI/genivi-dev-platform) on a future PR. EDIT: PR sent: https://github.com/GENIVI/genivi-dev-platform/pull/57