### PR TITLE
Change the SRC_URI for AudioManager

### DIFF
--- a/meta-genivi-dev/recipes-multimedia/audiomanager/audiomanager-demo_1.2.bb
+++ b/meta-genivi-dev/recipes-multimedia/audiomanager/audiomanager-demo_1.2.bb
@@ -6,11 +6,10 @@ LIC_FILES_CHKSUM = "file://AudioManagerPoC/README;md5=be0fe05c89ff7a2632eb080f72
 
 DEPENDS = "qtbase qtdeclarative qtwebkit"
 
-BRANCH = "Intreprid_stable_branch"
-VERSION = "6.1"
+SRCREV = "daf851ee7a41d1b0572c0c95e15f61e427ce97f1"
 
 SRC_URI = "\
-    git://github.com/GENIVI/AudioManager.git;branch=${BRANCH};tag=${VERSION};protocol=http \
+    git://github.com/GENIVI/AudioManager.git;protocol=http \
     file://0001-AudioManagerPoC-GENIVI-Alliance-Audio-Manager-proof-.patch \
     file://0002-AudioManagerPoC-add-support-for-Wayland-ivi-shell.patch \
     file://AudioManager_PoC.service \

--- a/meta-genivi-dev/recipes-multimedia/audiomanager/audiomanager-demo_1.2.bb
+++ b/meta-genivi-dev/recipes-multimedia/audiomanager/audiomanager-demo_1.2.bb
@@ -10,7 +10,7 @@ BRANCH = "Intreprid_stable_branch"
 VERSION = "6.1"
 
 SRC_URI = "\
-    git://git.projects.genivi.org/AudioManager.git;branch=${BRANCH};tag=${VERSION};protocol=http \
+    git://github.com/GENIVI/AudioManager.git;branch=${BRANCH};tag=${VERSION};protocol=http \
     file://0001-AudioManagerPoC-GENIVI-Alliance-Audio-Manager-proof-.patch \
     file://0002-AudioManagerPoC-add-support-for-Wayland-ivi-shell.patch \
     file://AudioManager_PoC.service \


### PR DESCRIPTION
Change the SRC_URI for AudioManager from "git.projects.genivi.org" to
"github.com".

Add SRCREV since branch tracking is dangerous and can not be used offline.

Signed-off-by: Viktor Sjölind <viktor.sjolind@pelagicore.com>