### PR TITLE
Add newer sota-client with rvi and genivi-swm

### DIFF
--- a/meta-genivi-dev/recipes-dev-platform/packagegroups/packagegroup-gdp-rvi.bb
+++ b/meta-genivi-dev/recipes-dev-platform/packagegroups/packagegroup-gdp-rvi.bb
@@ -16,4 +16,5 @@ ALLOW_EMPTY_${PN} = "1"
 RDEPENDS_${PN} += "\
     rvi \
     rvi-sota-client \
+    genivi-swm \
     "

--- a/meta-genivi-dev/recipes-sota/genivi-swm/files/lifecycle_manager.service
+++ b/meta-genivi-dev/recipes-sota/genivi-swm/files/lifecycle_manager.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Genivi Software Management
+Wants=network-online.target
+After=network.target network-online.target
+Requires=network-online.target
+
+[Service]
+Environment=PYTHONPATH=/usr/lib/genivi-swm/common/
+Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket
+ExecStart=/usr/bin/python /usr/lib/genivi-swm/lifecycle_manager/lifecycle_manager.py fg
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-genivi-dev/recipes-sota/genivi-swm/files/module_loader_ecu1.service
+++ b/meta-genivi-dev/recipes-sota/genivi-swm/files/module_loader_ecu1.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Genivi SLM module_loader_ecu1
+Wants=network-online.target
+After=network.target network-online.target
+Requires=network-online.target
+
+[Service]
+Environment=PYTHONPATH=/usr/lib/genivi-swm/common/
+Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket
+ExecStart=/usr/bin/python /usr/lib/genivi-swm/module_loader_ecu1/module_loader_ecu1.py fg
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-genivi-dev/recipes-sota/genivi-swm/files/org.genivi.SoftwareLoadingManager.conf
+++ b/meta-genivi-dev/recipes-sota/genivi-swm/files/org.genivi.SoftwareLoadingManager.conf
@@ -1,0 +1,15 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+    <policy user="root">
+        <allow own="org.genivi.SoftwareLoadingManager"/>
+        <allow own="org.genivi.PartitionManager"/>
+        <allow own="org.genivi.LifecycleManager"/>
+        <allow own="org.genivi.PackageManager"/>
+        <allow own="org.genivi.ModuleLoaderEcu1"/>
+    </policy>
+    <policy context="default">
+        <allow send_destination="*"/>
+        <allow send_interface="*"/>
+    </policy>
+</busconfig>

--- a/meta-genivi-dev/recipes-sota/genivi-swm/files/package_manager.service
+++ b/meta-genivi-dev/recipes-sota/genivi-swm/files/package_manager.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Genivi SLM Package Manager
+Wants=network-online.target
+After=network.target network-online.target
+Requires=network-online.target
+
+[Service]
+Environment=PYTHONPATH=/usr/lib/genivi-swm/common/
+Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket
+Environment=SLM_PACKAGE_MANAGER=rpm
+Environment=SLM_SWM_SIMULATION=false
+ExecStart=/usr/bin/python /usr/lib/genivi-swm/package_manager/package_manager.py fg
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-genivi-dev/recipes-sota/genivi-swm/files/partition_manager.service
+++ b/meta-genivi-dev/recipes-sota/genivi-swm/files/partition_manager.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Genivi SLM partition_manager
+Wants=network-online.target
+After=network.target network-online.target
+Requires=network-online.target
+
+[Service]
+Environment=PYTHONPATH=/usr/lib/genivi-swm/common/
+Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket
+Environment=SLM_SWM_SIMULATION=false
+ExecStart=/usr/bin/python /usr/lib/genivi-swm/partition_manager/partition_manager.py fg
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-genivi-dev/recipes-sota/genivi-swm/files/software_loading_manager.service
+++ b/meta-genivi-dev/recipes-sota/genivi-swm/files/software_loading_manager.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Genivi Software Loading Manager
+Wants=network-online.target
+After=network.target network-online.target
+Requires=network-online.target
+
+[Service]
+Environment=PYTHONPATH=/usr/lib/genivi-swm/common/
+Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket
+Environment=SLM_PACKAGE_MANAGER=rpm
+Environment=SLM_SWM_SIMULATION=false
+ExecStart=/usr/bin/python /usr/lib/genivi-swm/software_loading_manager/software_loading_manager.py fg
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-genivi-dev/recipes-sota/genivi-swm/genivi-swm_git.bb
+++ b/meta-genivi-dev/recipes-sota/genivi-swm/genivi-swm_git.bb
@@ -1,0 +1,60 @@
+DESCRIPTION = "Genivi Software Loading Manager"
+SECTION = "base"
+LICENSE = "MPL-2.0"
+LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=8d2127b230519ce4ad2c16070bdeb7b3"
+
+SRCREV = "1ccca6c731da1e26752fbf2d2cdef18fe7e7fbb3"
+SRC_URI = "\
+    git://github.com/advancedtelematic/genivi_swm;branch=gdp-build;protocol=https \
+    file://package_manager.service \
+    file://partition_manager.service \
+    file://lifecycle_manager.service \
+    file://software_loading_manager.service \
+    file://module_loader_ecu1.service \
+    file://org.genivi.SoftwareLoadingManager.conf \
+    "
+
+PR = "r0"
+
+S = "${WORKDIR}/git"
+
+FILES_${PN} = " \
+    ${libdir}/${PN}/* \
+    ${systemd_system_unitdir}/package_manager.service \
+    ${systemd_system_unitdir}/partition_manager.service \
+    ${systemd_system_unitdir}/module_loader_ecu1.service \
+    ${systemd_system_unitdir}/software_loading_manager.service \
+    ${systemd_system_unitdir}/lifecycle_manager.service \
+    ${sysconfdir}/dbus-1/system.d/org.genivi.SoftwareLoadingManager.conf \
+    "
+
+DEPENDS = "systemd"
+
+RDEPENDS_${PN} = " \
+    python-subprocess \
+    python-pygobject \
+    python-dbus \
+    python-storm \
+    squashfs-tools \
+    rpm \
+    "
+
+inherit systemd
+SYSTEMD_SERVICE_${PN} = "package_manager.service partition_manager.service module_loader_ecu1.service software_loading_manager.service lifecycle_manager.service"
+
+do_install () {
+    install -d ${D}${libdir}/${PN}
+
+    # TODO: Probably want to just copy in the needed files
+    cp -r ${S}/* ${D}${libdir}/${PN}
+
+    install -d ${D}${systemd_system_unitdir}
+    install -c "${WORKDIR}/package_manager.service" ${D}${systemd_system_unitdir}
+    install -c "${WORKDIR}/partition_manager.service" ${D}${systemd_system_unitdir}
+    install -c "${WORKDIR}/module_loader_ecu1.service" ${D}${systemd_system_unitdir}
+    install -c "${WORKDIR}/software_loading_manager.service" ${D}${systemd_system_unitdir}
+    install -c "${WORKDIR}/lifecycle_manager.service" ${D}${systemd_system_unitdir}
+
+    install -d ${D}${sysconfdir}/dbus-1/system.d/
+    install -c "${WORKDIR}/org.genivi.SoftwareLoadingManager.conf" ${D}${sysconfdir}/dbus-1/system.d
+}

--- a/meta-genivi-dev/recipes-sota/python-pygobject/python-pygobject/obsolete_automake_macros.patch
+++ b/meta-genivi-dev/recipes-sota/python-pygobject/python-pygobject/obsolete_automake_macros.patch
@@ -1,0 +1,23 @@
+Upstream-Status: Accepted [https://bugzilla.gnome.org/show_bug.cgi?id=691101]
+
+Signed-off-by: Marko Lindqvist <cazfi74@gmail.com>
+diff -Nurd pygobject-2.27.91/configure.ac pygobject-2.27.91/configure.ac
+--- pygobject-2.27.91/configure.ac	2011-02-23 22:14:37.000000000 +0200
++++ pygobject-2.27.91/configure.ac	2013-01-03 05:13:44.034949954 +0200
+@@ -35,7 +35,7 @@
+ AC_DEFINE(PYGOBJECT_MICRO_VERSION, pygobject_micro_version, [pygobject micro version])
+ AC_SUBST(PYGOBJECT_MICRO_VERSION, pygobject_micro_version)
+
+-AM_CONFIG_HEADER(config.h)
++AC_CONFIG_HEADERS(config.h)
+ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES(yes)])
+ AM_INIT_AUTOMAKE(foreign)
+ AM_MAINTAINER_MODE
+@@ -82,7 +82,6 @@
+ m4_ifdef([LT_OUTPUT], [LT_OUTPUT])
+ AC_ISC_POSIX
+ AC_PROG_CC
+-AM_PROG_CC_STDC
+ AM_PROG_CC_C_O
+
+ # check that we have the minimum version of python necisary to build

--- a/meta-genivi-dev/recipes-sota/python-pygobject/python-pygobject_2.28.3.bb
+++ b/meta-genivi-dev/recipes-sota/python-pygobject/python-pygobject_2.28.3.bb
@@ -1,0 +1,55 @@
+# Copied from http://git.yoctoproject.org/cgit/cgit.cgi/poky/tree/meta/recipes-devtools/python?h=jethro d462015
+
+SUMMARY = "Python GObject bindings"
+SECTION = "devel/python"
+LICENSE = "LGPLv2.1"
+
+RECIPE_NO_UPDATE_REASON = "Newer versions of python-pygobject depend on gobject-introspection which doesn't cross-compile"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=a916467b91076e631dd8edb7424769c7"
+DEPENDS = "python python-pygobject-native libffi glib-2.0"
+DEPENDS_class-native = "python-native libffi-native glib-2.0-native"
+RDEPENDS_class-native = ""
+
+MAJ_VER = "${@d.getVar('PV',1).split('.')[0]}.${@d.getVar('PV',1).split('.')[1]}"
+
+SRC_URI = "${GNOME_MIRROR}/pygobject/${MAJ_VER}/pygobject-${PV}.tar.bz2 \
+           file://obsolete_automake_macros.patch \
+"
+
+# libtool-native doesn't have fixinstall.patch applied which means
+# that libs get relinked at installation time. This triggers a 
+# relinking along the lines of:
+# gcc -L/tmp/foo/media/build1/poky/build/tmp/sysroots/x86_64-linux/usr/lib -lpyglib-2.0-python -o .libs/_glib.so
+# where /tmp/foo is DESTDIR and pyglib-2.0-python may be installed/reinstalled
+# at the same time as the gcc command runs.
+# If this happens between the handoff between gcc and ld, you can see:
+# /bin/ld: cannot find -lpyglib-2.0-python
+# Adding a dependency rule like  install-pyglibLTLIBRARIES: install-libLTLIBRARIES
+# would be ideal but automake can't cope with that without manually 
+# defining the whole function. Give up and disable parallel make in native builds.
+PARALLEL_MAKEINST_class-native = ""
+
+SRC_URI[md5sum] = "aa64900b274c4661a5c32e52922977f9"
+SRC_URI[sha256sum] = "7da88c169a56efccc516cebd9237da3fe518a343095a664607b368fe21df95b6"
+S = "${WORKDIR}/pygobject-${PV}"
+
+EXTRA_OECONF += "--disable-introspection"
+
+inherit autotools distutils-base pkgconfig
+
+# necessary to let the call for python-config succeed
+export BUILD_SYS
+export HOST_SYS
+export STAGING_INCDIR
+export STAGING_LIBDIR
+
+PACKAGES += "${PN}-lib"
+
+RDEPENDS_${PN} += "python-textutils"
+
+FILES_${PN} = "${libdir}/python*"
+FILES_${PN}-lib = "${libdir}/lib*.so.*"
+FILES_${PN}-dev += "${bindir} ${datadir}"
+
+BBCLASSEXTEND = "native"

--- a/meta-genivi-dev/recipes-sota/python-storm/python-storm_0.20.bb
+++ b/meta-genivi-dev/recipes-sota/python-storm/python-storm_0.20.bb
@@ -1,0 +1,36 @@
+SUMMARY = "Storm is an object-relational mapper (ORM) for Python developed at Canonical"
+HOMEPAGE = "https://pypi.python.org/pypi/storm"
+LICENSE = "LGPL-2.1"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=e91355d8a6f8bd8f7c699d62863c7303"
+
+SRC_URI = "https://launchpad.net/storm/trunk/0.20/+download/storm-0.20.tar.gz"
+SRC_URI[md5sum] = "8628503141f0f06c0749d607ac09b9c7"
+SRC_URI[sha256sum] = "0fa70043bb1a1c178c2f760db35f5956244cecf50dab7fb22d78be7507726603"
+
+S = "${WORKDIR}/storm-0.20"
+
+inherit setuptools
+
+RDEPENDS_${PN} += "python \
+    python-setuptools \
+    python-pkgutil \
+    python-modules \
+    "
+
+do_compile_prepend() {
+    BUILD_SYS=${BUILD_SYS} HOST_SYS=${HOST_SYS} \
+    ${STAGING_BINDIR_NATIVE}/python-native/python setup.py install || true
+}
+
+# need to export these variables for python-config to work
+export PYTHONPATH
+export BUILD_SYS
+export HOST_SYS
+export STAGING_INCDIR
+export STAGING_LIBDIR
+
+FILES_${PN} = " \
+    ${libdir}/${PYTHON_DIR}/site-packages \
+    ${libdir}/${PYTHON_DIR}/site-packages/*"
+
+FILES_${PN}-dbg += "${libdir}/${PYTHON_DIR}/site-packages/.debug/*"

--- a/meta-genivi-dev/recipes-sota/rvi-sota-client/files/org.genivi.SotaClient.conf
+++ b/meta-genivi-dev/recipes-sota/rvi-sota-client/files/org.genivi.SotaClient.conf
@@ -1,0 +1,11 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <policy user="root">
+    <allow own="org.genivi.SotaClient"/>
+  </policy>
+  <policy context="default">
+    <allow send_destination="*"/>
+    <allow send_interface="*"/>
+  </policy>
+</busconfig>

--- a/meta-genivi-dev/recipes-sota/rvi-sota-client/files/sota.toml
+++ b/meta-genivi-dev/recipes-sota/rvi-sota-client/files/sota.toml
@@ -1,0 +1,32 @@
+[core]
+server = "https://localhost"
+polling = false
+polling_sec = 10
+
+[device]
+uuid = "c2855cbb-20fc-4672-9505-ec839ac789e6"
+system_info = "system_info.sh"
+packages_dir = "/tmp/"
+package_manager = "off"
+certificates_path = "/etc/sota_certificates"
+
+[gateway]
+console = false
+dbus = true
+http = false
+rvi = true
+socket = false
+websocket = false
+
+[rvi]
+client = "http://127.0.0.1:8901"
+storage_dir = "/var/sota"
+timeout = 20
+
+[dbus]
+name = "org.genivi.SotaClient"
+path = "/org/genivi/SotaClient"
+interface = "org.genivi.SotaClient"
+software_manager = "org.genivi.SoftwareLoadingManager"
+software_manager_path = "/org/genivi/SoftwareLoadingManager"
+timeout = 60

--- a/meta-genivi-dev/recipes-sota/rvi-sota-client/files/sota_client.service
+++ b/meta-genivi-dev/recipes-sota/rvi-sota-client/files/sota_client.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=SOTA Client
+Wants=network-online.target
+After=network.target network-online.target rvi.service
+Requires=network-online.target
+
+[Service]
+RestartSec=5
+Restart=on-failure
+Environment="RUST_LOG=info"
+Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket
+DefaultTimeoutStopSec=5
+ExecStartPre=/bin/sleep 45
+ExecStart=/usr/bin/sota_client --config /etc/sota.toml
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-genivi-dev/recipes-sota/rvi-sota-client/rvi-sota-client_git.bbappend
+++ b/meta-genivi-dev/recipes-sota/rvi-sota-client/rvi-sota-client_git.bbappend
@@ -1,0 +1,19 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI += "\
+    file://sota.toml \
+    file://sota_client.service \
+    file://org.genivi.SotaClient.conf \
+    "
+
+do_install_append () {
+    install -d ${D}${sysconfdir}
+    install -c ${WORKDIR}/sota.toml ${D}${sysconfdir}
+    install -c ${WORKDIR}/sota_client.service ${D}${systemd_unitdir}/system
+    install -d ${D}${sysconfdir}/dbus-1/system.d/
+    install -c ${WORKDIR}/org.genivi.SotaClient.conf ${D}${sysconfdir}/dbus-1/system.d
+}
+
+FILES_${PN} += " \
+    ${sysconfdir}/sota.toml \
+    ${sysconfdir}/dbus-1/system.d/org.genivi.SotaClient.conf \
+    "

--- a/meta-genivi-dev/recipes-sota/rvi/files/device_id
+++ b/meta-genivi-dev/recipes-sota/rvi/files/device_id
@@ -1,0 +1,1 @@
+genivi.org/device/c2855cbb-20fc-4672-9505-ec839ac789e6

--- a/meta-genivi-dev/recipes-sota/rvi/files/rvi.service
+++ b/meta-genivi-dev/recipes-sota/rvi/files/rvi.service
@@ -1,0 +1,26 @@
+# systemd(8) setup usde by Yocto Project
+[Unit]
+Description=Remote Vehicle Interaction Service
+Wants=network-online.target
+After=getty@tty2.service
+
+[Service]
+Environment="HOME=/opt/rvi_core"
+Environment="RVI_PORT=8900"
+Environment="CONFIG=/etc/opt/rvi/rvi.config"
+Environment="RVI_BACKEND=38.101.164.230"
+
+StandardOutput=journal
+StandardError=journal
+ExecStart=/bin/sh -c "RVI_MYIP=$(/sbin/ip route | /usr/bin/awk '/default/ { print $3 }') CONFIG=/etc/opt/rvi/rvi.config RVI_BACKEND=38.101.164.230 /opt/rvi_core/rvi_ctl -c /etc/opt/rvi/rvi.config console"
+ExecStop=/opt/rvi_core/rvi_ctl stop
+GuessMainPID=yes
+RemainAfterExit=yes
+
+StandardInput=tty
+TTYPath=/dev/tty2
+TTYReset=yes
+TTYVHangup=yes
+
+[Install]
+WantedBy=graphical.target multi-user.target

--- a/meta-genivi-dev/recipes-sota/rvi/rvi_git.bbappend
+++ b/meta-genivi-dev/recipes-sota/rvi/rvi_git.bbappend
@@ -1,0 +1,22 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI += "\
+    file://rvi.service \
+    file://device_id \
+    "
+
+do_install_append () {
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/rvi.service ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/device_id ${D}${sysconfdir}/opt/rvi/device_id
+    rm ${D}${sysconfdir}/init.d/rvi
+}
+
+inherit systemd
+
+INITSCRIPT_NAME = ""
+INITSCRIPT_PARAMS = ""
+
+pkg_postinst_${PN} () {
+    #!/bin/sh -e
+    true
+}


### PR DESCRIPTION
[GDP-183] https://at.projects.genivi.org/~/GDP-183

To allow genivi SOTA to support GDP, the following changes were made:

- Add rvi.bbappend to start RVI using systemd and configure it to use sota.genivi.org backend
- Add rvi-sota-client_git.bbappend for to configure it communicate with RVI and genivi-swm
- Add genivi-swm recipe, manages package updates, updates to ECUs etc. It is required by rvi-sota-client when using RVI. 
- Add python-storm recipe, a dependency of genivi-swm
- Downgrade python-pygobject 3.18.2 -> 2.28.3 as import gobject is failing with 3.18.2 
from poky/meta layer