### PR TITLE
Lifecycle: Add new systemd targets

### DIFF
--- a/meta-genivi-dev/recipes-core/systemd/systemd/focused.target
+++ b/meta-genivi-dev/recipes-core/systemd/systemd/focused.target
@@ -1,0 +1,10 @@
+#  This file is part of GENIVI-DEV-PLATFORM
+#
+#  GENIVI-DEV-PLATFORM is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Unit]
+Description=Responsible for starting GENIVI components directly being used for the user context.
+After=basic.target

--- a/meta-genivi-dev/recipes-core/systemd/systemd/lazy.target
+++ b/meta-genivi-dev/recipes-core/systemd/systemd/lazy.target
@@ -1,0 +1,10 @@
+#  This file is part of GENIVI-DEV-PLATFORM
+#
+#  GENIVI-DEV-PLATFORM is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Unit]
+Description=Responsible for starting lazy background applications.
+After=unfocused.target

--- a/meta-genivi-dev/recipes-core/systemd/systemd/unfocused.target
+++ b/meta-genivi-dev/recipes-core/systemd/systemd/unfocused.target
@@ -1,0 +1,10 @@
+#  This file is part of GENIVI-DEV-PLATFORM
+#
+#  GENIVI-DEV-PLATFORM is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Unit]
+Description=Contains all applications in the system.
+After=focused.target

--- a/meta-genivi-dev/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-genivi-dev/recipes-core/systemd/systemd_%.bbappend
@@ -2,9 +2,18 @@ FILESEXTRAPATHS_append := ":${THISDIR}/${PN}"
 
 SRC_URI_append = " \
     file://systemd-user-enable-optional-pam_systemd.so-session.patch \
-    file://system.conf"
+    file://system.conf \
+
+    file://focused.target \
+    file://unfocused.target \
+    file://lazy.target \
+    "
 
 do_install_append() {
     install -d ${D}${sysconfdir}
     install -m 0644 ${WORKDIR}/system.conf ${D}${sysconfdir}/systemd/system.conf
+
+    install -m 0644 ${WORKDIR}/focused.target   ${D}$/lib/systemd/system/focused.target
+    install -m 0644 ${WORKDIR}/unfocused.target ${D}$/lib/systemd/system/unfocused.target
+    install -m 0644 ${WORKDIR}/lazy.target      ${D}$/lib/systemd/system/lazy.target
 }


### PR DESCRIPTION
Add the systemd targets: focused, unfocused and lazy.
These targets will later be used to integrate the GDP-lifecycle.

Signed-off-by: Viktor Sjölind <viktor.sjolind@pelagicore.com>