### PR TITLE
NodeStateTest and systemd targets

### DIFF
--- a/meta-genivi-dev/recipes-core/systemd/systemd/focused.target
+++ b/meta-genivi-dev/recipes-core/systemd/systemd/focused.target
@@ -1,0 +1,3 @@
+[Unit]
+Description=Responsible for starting GENIVI components directly being used for the user context.
+After=basic.target

--- a/meta-genivi-dev/recipes-core/systemd/systemd/lazy.target
+++ b/meta-genivi-dev/recipes-core/systemd/systemd/lazy.target
@@ -1,0 +1,3 @@
+[Unit]
+Description=Responsible for starting lazy background applications.
+After=unfocused.target

--- a/meta-genivi-dev/recipes-core/systemd/systemd/unfocused.target
+++ b/meta-genivi-dev/recipes-core/systemd/systemd/unfocused.target
@@ -1,0 +1,3 @@
+[Unit]
+Description=Contains all applications in the system.
+After=focused.target

--- a/meta-genivi-dev/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-genivi-dev/recipes-core/systemd/systemd_%.bbappend
@@ -2,9 +2,17 @@ FILESEXTRAPATHS_append := ":${THISDIR}/${PN}"
 
 SRC_URI_append = " \
     file://systemd-user-enable-optional-pam_systemd.so-session.patch \
-    file://system.conf"
+    file://system.conf \
+    file://focused.target \
+    file://unfocused.target \
+    file://lazy.target \
+    "
 
 do_install_append() {
     install -d ${D}${sysconfdir}
     install -m 0644 ${WORKDIR}/system.conf ${D}${sysconfdir}/systemd/system.conf
+
+    install -m 0644 ${WORKDIR}/focused.target   ${D}${systemd_system_unitdir}/focused.target
+    install -m 0644 ${WORKDIR}/unfocused.target ${D}${systemd_system_unitdir}/unfocused.target
+    install -m 0644 ${WORKDIR}/lazy.target      ${D}${systemd_system_unitdir}/lazy.target
 }

--- a/meta-genivi-dev/recipes-extended/node-state-manager/node-state-manager_2.0.0.bbappend
+++ b/meta-genivi-dev/recipes-extended/node-state-manager/node-state-manager_2.0.0.bbappend
@@ -1,0 +1,5 @@
+EXTRA_OECONF_append=" --with-nsmc=NodeStateMachineTest "
+
+do_install_append() {
+    install -m 755 ${B}/NodeStateMachineTest/NodeStateTest ${D}${bindir}/NodeStateTest
+}


### PR DESCRIPTION
[GDP-3](https://at.projects.genivi.org/jira/browse/GDP-3)
Add the systemd targets: focused, unfocused and lazy. These targets are
required by the specifiction of the GENIVI lifecycle to start the HMI and
provide the last user context.

[GDP-554](https://at.projects.genivi.org/jira/browse/GDP-554)
Install NodeStateTest on the GDP platfrom. It is used to demonstrate that
the NodeSateManager setup works on the platform.

