### PR TITLE
meta-iot-web: Ship iotivity-node using metapackage

### DIFF
--- a/meta-genivi-dev/recipes-dev-platform/images/genivi-dev-platform.bb
+++ b/meta-genivi-dev/recipes-dev-platform/images/genivi-dev-platform.bb
@@ -29,6 +29,7 @@ IMAGE_INSTALL_append = " \
     packagegroup-gdp-gps \
     packagegroup-gdp-hmi \
     packagegroup-iotivity \
+    packagegroup-nodejs-runtime \
     packagegroup-gdp-qt5 \
     packagegroup-gdp-rvi \
     packagegroup-gdp-dev \


### PR DESCRIPTION
Please first merge:
https://github.com/GENIVI/genivi-dev-platform/pull/61


Metapackage packagegroup-nodejs-runtime pulls
IoTivity NodeJS bindings and dependencies.

[GDP-160] meta-genivi-ocf-demo merging

Signed-off-by: Philippe Coval <philippe.coval@osg.samsung.com>