### PR TITLE
gdp-new-hmi: Change name to gdp-hmi

### DIFF
--- a/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/gdp-new-hmi.bb
+++ b/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/gdp-new-hmi.bb
@@ -1,5 +1,5 @@
 SRC_URI = "git://github.com/GENIVI/hmi-layout-gdp.git"
-SRCREV = "d0ca9d072012d8ac333537d9b922d9242e022efe"
+SRCREV = "79a4f69e7588a6efc4b4c95abec7794216588087"
 LICENSE  = "MPL-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=815ca599c9df247a0c7f619bab123dad"
 
@@ -22,7 +22,7 @@ SRC_URI_append_rcar-gen2 ="\
 
 FILES_${PN} += "\
     ${libdir}/* \
-    /opt/genivi-11-hmi/bin/genivi-11-hmi \
+    /opt/gdp-hmi/bin/gdp-hmi \
     /usr/share/applications/* \
     ${systemd_unitdir}/* \
     /home/* \

--- a/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/gdp-new-hmi/gdp-new-hmi.service
+++ b/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/gdp-new-hmi/gdp-new-hmi.service
@@ -5,7 +5,7 @@ After=weston.service
 
 [Service]
 Environment=LD_PRELOAD=/usr/lib/libEGL.so
-ExecStart=/opt/genivi-11-hmi/bin/genivi-11-hmi -platform wayland
+ExecStart=/opt/gdp-hmi/bin/gdp-hmi -platform wayland
 Restart=always
 RestartSec=5
 


### PR DESCRIPTION
genivi-11-hmi that is previous binary name is only for GDP-11 and need
to change general naming. So I change the name to gdp-hmi.

Signed-off-by: Changhyeok Bae <changhyeok.bae@gmail.com>