### PR TITLE
fuel stop advisor: Add service for simulate data for FSA (Update the receipe)

### DIFF
--- a/meta-genivi-dev/recipes-extended/automotive-message-broker/automotive-message-broker_git.bb
+++ b/meta-genivi-dev/recipes-extended/automotive-message-broker/automotive-message-broker_git.bb
@@ -34,9 +34,10 @@ do_install_append() {
     install -m 0644 ${WORKDIR}/ambd.service ${D}${systemd_unitdir}/system
     
     install -d ${D}${libdir}/systemd/user/
-    install -m 0644 ${WORKDIR}/ambd_fsa.service ${D}${libdir}/systemd/user/ambd_fsa.service
+    install -m 0644 ${WORKDIR}/ambd_fsa.service ${D}${libdir}/systemd/user/
     mkdir -p ${D}/home/root/.config/systemd/user/default.target.wants
-    ln -sf ${libdir}/systemd/user/ambd_fsa.service ${D}/home/root/.config/systemd/user/default.target.wants/ambd_fsa.service.service
+    ln -sf ${libdir}/systemd/user/ambd_fsa.service \ 
+        ${D}/home/root/.config/systemd/user/default.target.wants/ambd_fsa.service
 
 }
 

--- a/meta-genivi-dev/recipes-extended/automotive-message-broker/automotive-message-broker_git.bb
+++ b/meta-genivi-dev/recipes-extended/automotive-message-broker/automotive-message-broker_git.bb
@@ -17,6 +17,7 @@ SRCREV = "c216955d16ca275159891cad296217094d972390"
 
 SRC_URI += "file://amb_allow_sessionbus.patch \
             file://ambd.service \
+            file://ambd_fsa.service \
             "
 
 EXTRA_OECMAKE += "-Denable_icecc=OFF"
@@ -31,8 +32,16 @@ do_install_append() {
 
     install -d ${D}${systemd_unitdir}/system/
     install -m 0644 ${WORKDIR}/ambd.service ${D}${systemd_unitdir}/system
+    
+    install -d ${D}${libdir}/systemd/user/
+    install -m 0644 ${WORKDIR}/ambd_fsa.service ${D}${libdir}/systemd/user/ambd_fsa.service
+    mkdir -p ${D}/home/root/.config/systemd/user/default.target.wants
+    ln -sf ${libdir}/systemd/user/ambd_fsa.service ${D}/home/root/.config/systemd/user/default.target.wants/ambd_fsa.service.service
+
 }
 
-FILES_${PN} += "${systemd_unitdir}/ambd.service"
+FILES_${PN} += "${systemd_unitdir}/system/ambd.service"
+FILES_${PN} += "${libdir}/systemd/user/*.service \
+                /home/root/.config/systemd/user/default.target.wants/*.service"
 
 INSANE_SKIP_${PN} = "dev-deps"


### PR DESCRIPTION
fuel stop advisor: Add service for simulate data for FSA (Update the receipe)

In order to have data simulated in Fuel Stop Advisor, need to add
automotive message broker with a particular configuration file in
dbus session and systemd user.

[GDP-15] Part of the Integrate LBS / FSA into GDP