### PR TITLE
fuel stop advisor: Add service for simulate data for FSA (Service File)

### DIFF
--- a/meta-genivi-dev/recipes-extended/automotive-message-broker/automotive-message-broker/ambd_fsa.service
+++ b/meta-genivi-dev/recipes-extended/automotive-message-broker/automotive-message-broker/ambd_fsa.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Automotive Message Broker for FSA configuration file
+Requires=dbus.service
+After=dbus.service
+
+[Service]
+ExecStart=/usr/bin/ambd --config  /etc/ambd/logreplayerconfig.in.json
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
fuel stop advisor: Add service for simulate data for FSA (Service File)

In order to have data simulated in Fuel Stop Advisor, need to add
automotive message broker with a particular configuration file in
dbus session and systemd user.

[GDP-15] Part of the Integrate LBS / FSA into GDP