### PR TITLE
CONTRIBUTING: Create file with reference to wiki

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,4 @@
+Guidelines
+==========
+
+Please follow the git rules defined at https://at.projects.genivi.org/wiki/display/PROJ/Rules+for+Commit+Messages


### PR DESCRIPTION
Create the file "CONTRIBUTING.md" with a link to a page on the genivi wiki defining the rules for git commit messages. The purpose of having this as a file in github is that it makes github show a notification reminding people to read the developer guidelines before publishing a puill-request.