### PR TITLE
Aktualizr improvements

### DIFF
--- a/meta-genivi-dev/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/meta-genivi-dev/recipes-sota/aktualizr/aktualizr_git.bb
@@ -10,7 +10,7 @@ inherit cmake systemd
 
 S = "${WORKDIR}/git"
 
-SRCREV = "95405ab5e3828daf954fdd8bd5774ccb58cf75bb"
+SRCREV = "c2f7d18eaa9e86c0e2881ab8fa65adbda316a499"
 
 SRC_URI = " \
     git://github.com/advancedtelematic/aktualizr \

--- a/meta-genivi-dev/recipes-sota/rvi-default-config/rvi-default-config/sota.toml
+++ b/meta-genivi-dev/recipes-sota/rvi-default-config/rvi-default-config/sota.toml
@@ -23,7 +23,7 @@ websocket = false
 [rvi]
 client = "http://127.0.0.1:8901"
 client_config = "/etc/rvi/conf.json"
-# node_host = "38.101.164.230"
+node_host = "sota.genivi.org"
 storage_dir = "/var/sota"
 timeout = 20
 


### PR DESCRIPTION
Hi,

This GitHub pull request contains the following patches:
* Update Aktualizr to a version that gracefully exists if the RVI configurations are missing in sota.toml
* Set sota.genivi.org as a default RVI node in sota.toml

Best regards,
Leon