### PR TITLE
Add CDL concept demo codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,15 @@ URI: https://git.linaro.org/openembedded/meta-linaro.git
 * branch: krogoth
 * revision: fd9a7c36813cc3fd1761cfffee28349450064578
 
+## The Renesas R-Car Gen3 M3/H3 Starter Kit boards depend in addition on: ##
+URI: https://github.com/slawr/renesas-rcar-gen3.git
+* branch: genivi-11
+* revision: 4758a558bb3badd7108b04b8c43a8a3fbe61b958
+
+URI: https://git.linaro.org/openembedded/meta-linaro.git
+* branch: krogoth
+* revision: 2f51d38048599d9878f149d6d15539fb97603f8f
+
 ## The Renesas R-Car Gen2 Silk & Porter boards depend in addition on: ##
 URI: git://github.com/slawr/meta-renesas.git
 * revision: 4758a558bb3badd7108b04b8c43a8a3fbe61b958

--- a/meta-genivi-dev/recipes-cdl/cdl-concept-demo/cdl-concept-demo.bb
+++ b/meta-genivi-dev/recipes-cdl/cdl-concept-demo/cdl-concept-demo.bb
@@ -1,0 +1,17 @@
+# Copyright (C) 2017 GENIVI Alliance
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+SUMMARY = "CDL Concept Demo"
+LICENSE  = "MPL-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=9741c346eef56131163e13b9db1241b3"
+SRC_URI = "git://github.com/GENIVI/car-data-logger.git;branch=proof-of-concept;protocol=https"
+SRCREV  = "14a44c1d0db2b02582bcdf9e38b0947677c6f485"
+
+DEPENDS = "qtbase qtdeclarative vsomeip common-api-c++-someip dbus dlt-daemon common-api-c++-dbus common-api-c++"
+
+S = "${WORKDIR}/git"
+
+inherit qmake5
+
+FILES_${PN} += "/opt/cdl/*"
+INSANE_SKIP_${PN} = "dev-so"

--- a/meta-genivi-dev/recipes-dev-platform/images/genivi-dev-platform.bb
+++ b/meta-genivi-dev/recipes-dev-platform/images/genivi-dev-platform.bb
@@ -33,6 +33,7 @@ IMAGE_INSTALL_append = " \
     packagegroup-gdp-qt5 \
     packagegroup-gdp-rvi \
     packagegroup-gdp-dev \
+    packagegroup-gdp-cdl \
     "
 
 IMAGE_INSTALL_append_rcar-gen2 = " \

--- a/meta-genivi-dev/recipes-dev-platform/packagegroups/packagegroup-gdp-cdl.bb
+++ b/meta-genivi-dev/recipes-dev-platform/packagegroups/packagegroup-gdp-cdl.bb
@@ -1,0 +1,19 @@
+# Copyright (C) 2017 GENIVI Alliance
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+DESCRIPTION = "GENIVI Development Platform CDL package group"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${IVI_COREBASE}/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
+
+# Avoid hardcoding the full layer path into the checksums
+LIC_FILES_CHKSUM[vardepsexclude] += "IVI_COREBASE"
+
+inherit packagegroup
+
+PACKAGES = "\
+    packagegroup-gdp-cdl \
+    "
+
+RDEPENDS_${PN} += "\
+    cdl-concept-demo \
+    "


### PR DESCRIPTION
This PR includes the initial integration for CDL concept demo codes into GDP.
The CDL Concept Demo was not yet integrated with the GDP HMI Launcher because it was designed to run different binaries on three GDP devices respectively.
Currently, each GDP device must be tested by running it through a pre-provided script included in the image.
This code will be able to integrate with the HMI Launcher in the future.

[GDP-500] Integrate Car Data Logger (CDL) into GDP
