### PR TITLE
gdp-hmi: Bump to version supporting NSM Shutdown

### DIFF
--- a/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/gdp-new-hmi.bb
+++ b/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/gdp-new-hmi.bb
@@ -1,5 +1,5 @@
 SRC_URI = "git://github.com/GENIVI/hmi-layout-gdp.git"
-SRCREV = "79a4f69e7588a6efc4b4c95abec7794216588087"
+SRCREV = "6e7bf77403ffd603bce718e120bbc26a24a78aa3"
 LICENSE  = "MPL-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=9741c346eef56131163e13b9db1241b3"
 


### PR DESCRIPTION
Bump the GDP HMI to a version that registers as a NSM Shutdown Consumer.
That is sets up a DBus interface that will get called by NSM when the
system is about to shut down.

[GDP-570] Implement NSM Shutdown Consumer support for HMI

Signed-off-by: Viktor Sjölind <viktor.sjolind@pelagicore.com>