### PR TITLE
gdp-hmi: Bump version LUC and Desktopfiles

### DIFF
--- a/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/connectedhome.bb
+++ b/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/connectedhome.bb
@@ -4,7 +4,7 @@
 LICENSE  = "MPL-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=9741c346eef56131163e13b9db1241b3"
 SRC_URI = "git://github.com/GENIVI/connected-home"
-SRCREV  = "1bd1ec84ff730c2c8872781aab4733a9ffd32f1e"
+SRCREV  = "d839c4efb39ae0ad90e596d824564a0a27cf8ed7"
 
 SUMMARY = "Connected Home"
 DEPENDS = "qtbase qtdeclarative"

--- a/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/fmradio.bb
+++ b/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/fmradio.bb
@@ -4,7 +4,7 @@
 LICENSE  = "MPL-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=815ca599c9df247a0c7f619bab123dad"
 SRC_URI = "git://github.com/GENIVI/FMRadio"
-SRCREV  = "256c49af8719e2831a316e18240670df66ea2964"
+SRCREV  = "bd75139660ab8a2ddf3c1c60bb27cec31a452523"
 
 SUMMARY = "FM Radio"
 DEPENDS = "qtbase qtdeclarative"

--- a/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/gdp-new-hmi.bb
+++ b/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/gdp-new-hmi.bb
@@ -1,5 +1,5 @@
 SRC_URI = "git://github.com/GENIVI/hmi-layout-gdp.git"
-SRCREV = "6e7bf77403ffd603bce718e120bbc26a24a78aa3"
+SRCREV = "7de635f5d3daa25fcd104d15d6a0aac678b15121"
 LICENSE  = "MPL-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=9741c346eef56131163e13b9db1241b3"
 

--- a/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/hvac.bb
+++ b/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/hvac.bb
@@ -4,7 +4,7 @@
 LICENSE  = "MPL-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=9741c346eef56131163e13b9db1241b3"
 SRC_URI = "git://github.com/GENIVI/HVAC"
-SRCREV  = "ac15a42ce45379f7f80d0b5cc5a830a447239238"
+SRCREV  = "b5f215a90d7c32e75de6a5cc621f5bbc9e5617a0"
 
 SUMMARY = "HVAC"
 DEPENDS = "qtbase qtdeclarative dbus"
@@ -32,6 +32,9 @@ do_install_append() {
 
 FILES_${PN} += "\
     /opt/* \
+    ${libdir} \
+    ${libdir}/systemd \
+    ${libdir}/systemd/user \
     ${libdir}/systemd/user/* \
     /usr/share/* \
     "

--- a/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/ics-apps.inc
+++ b/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/ics-apps.inc
@@ -8,15 +8,16 @@ do_install_append() {
      install -m 0555 ${EXE} \
                 ${D}/opt/${APP}/bin/${EXE}
      install -d ${D}/usr/share/applications
-     install -m 0444 ${WORKDIR}/git/${APP}.app \
-                ${D}/usr/share/applications/${APP}.app
+     install -m 0444 ${WORKDIR}/git/${APP}.desktop \
+                ${D}/usr/share/applications/${APP}.desktop
      install -d ${D}/usr/lib/systemd/user/
-     install -m 0444 ${WORKDIR}/git/${APP}.service \
-                ${D}/usr/lib/systemd/user/${APP}.service
 }
 
 FILES_${PN} += "\
     /opt/${APP} \
     /usr/bin/${EXE} \
+    ${libdir} \
+    ${libdir}/systemd \
+    ${libdir}/systemd/user \
     ${libdir}/systemd/user/* \
     "


### PR DESCRIPTION
Bump the GDP HMI to a version that supports:
* handling applications through ".desktop" files instead of ".app" files
  together with ".service" files.
* Last User Context. That is when the HMI is restarted the last running
  application will automatically be started.

This change means that applications are no longer started through systemd
but instead through the HMI directly. This requires the HMI to be aware
of the DBus user session bus that some apps use.

[GDP-555] Mechanism to register & launch apps in HMI
[GDP-556] HMI implements Last User Context

Signed-off-by: Viktor Sjölind <viktor.sjolind@pelagicore.com>