### PR TITLE
Fix app rdepends

### DIFF
--- a/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/fmradio.bb
+++ b/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/fmradio.bb
@@ -8,6 +8,7 @@ SRCREV  = "256c49af8719e2831a316e18240670df66ea2964"
 
 SUMMARY = "FM Radio"
 DEPENDS = "qtbase qtdeclarative"
+RDEPENDS_${PN} = "qtquickcontrols-qmlplugins"
 
 SRC_URI_append ="\
     file://0002-Changed-surface-id-of-FM-radio.patch \

--- a/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/hvac.bb
+++ b/meta-genivi-dev/recipes-dev-hmi/genivi-dev-platform-hmi/hvac.bb
@@ -8,6 +8,7 @@ SRCREV  = "ac15a42ce45379f7f80d0b5cc5a830a447239238"
 
 SUMMARY = "HVAC"
 DEPENDS = "qtbase qtdeclarative dbus"
+RDEPENDS_${PN} = "qtquickcontrols-qmlplugins"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
This PR fixes FM-Radio and QML-Example not starting due to missing the pluging QtQuickControls found while testing the morty branch on hardware targets.