### PR TITLE
rvi-default-config: Update /etc/sota.toml

### DIFF
--- a/meta-genivi-dev/recipes-sota/rvi-default-config/rvi-default-config/sota.toml
+++ b/meta-genivi-dev/recipes-sota/rvi-default-config/rvi-default-config/sota.toml
@@ -26,6 +26,11 @@ client_config = "/etc/rvi/conf.json"
 node_host = "sota.genivi.org"
 storage_dir = "/var/sota"
 timeout = 20
+device_key =  "/etc/rvi/priv/keys/insecure_device_key.pem"
+device_cert = "/etc/rvi/priv/certificates/insecure_device_cert.crt"
+ca_cert = "/etc/rvi/priv/certificates/insecure_root_cert.crt"
+cert_dir =  "/etc/rvi/priv/certificates/"
+cred_dir = "/etc/rvi/priv/credentials/"
 
 [dbus]
 name = "org.genivi.SotaClient"


### PR DESCRIPTION
Update the default RVI configurations for Aktualizr, the SOTA client
written in C++, by adding paths to keys and certicates in sota.toml.

[GDP-551] Integrate Aktualizr (SOTA Client C++)

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>